### PR TITLE
「7: Installing Turbo in Your Application」の翻訳

### DIFF
--- a/turbo/handbook/installing.md
+++ b/turbo/handbook/installing.md
@@ -12,7 +12,7 @@ description: "Learn how to install Turbo in your application."
 
 Turbo can either be installed in compiled form by referencing the Turbo distributable script directly in the `<head>` of your application or through npm via a bundler like Webpack.
 
-Turbo は、アプリケーションの`<head>`内で直接 Turbo 配布スクリプトを参照してコンパイルされた形でインストールするか、Webpack などのバンドル経由で npm を使用してインストールすることができます。
+Turbo は、アプリケーションの `<head>` 内で直接 Turbo 配布スクリプトを参照してコンパイルされた形でインストールするか、Webpack などのバンドル経由で npm を使用してインストールすることができます。
 
 ## In Compiled Form
 
@@ -20,7 +20,7 @@ Turbo は、アプリケーションの`<head>`内で直接 Turbo 配布スク�
 
 You can download the latest distributable script from the GitHub releases page, then reference that in your `<script>` tag on your page. Or you can float on the latest release of Turbo using a CDN bundler like Skypack. See <a href="https://cdn.skypack.dev/@hotwired/turbo">https://cdn.skypack.dev/@hotwired/turbo</a> for more details.
 
-最新の配布スクリプトは、GitHub のリリースページからダウンロードできます。そして、ページ内の`<script>`タグ内で参照できます。または、Skypack のような CDN バンドラーを利用してリリースされた最新の Turbo を使用できます。詳細は、[https://cdn.skypack.dev/@hotwired/turbo](https://cdn.skypack.dev/@hotwired/turbo)を参照してください。
+最新の配布スクリプトは、GitHub のリリースページからダウンロードできます。そして、ページ内の `<script>` タグ内で参照できます。または、Skypack のような CDN バンドラーを利用してリリースされた最新の Turbo を使用できます。詳細は、[https://cdn.skypack.dev/@hotwired/turbo](https://cdn.skypack.dev/@hotwired/turbo) を参照してください。
 
 ## As An npm Package
 
@@ -28,7 +28,7 @@ You can download the latest distributable script from the GitHub releases page, 
 
 You can install Turbo from npm via the `npm` or `yarn` packaging tools. Then require or import that in your code:
 
-パッケージングツールの`npm`や`yarn`を利用して npm から Turbo をインストールできます。下記のようにコード内で require や import できます。
+パッケージングツールの `npm` や `yarn` を利用して npm から Turbo をインストールできます。下記のようにコード内で require や import できます。
 
 ```javascript
 import * as Turbo from "@hotwired/turbo";


### PR DESCRIPTION
## やったこと
- 7: Installing Turbo in Your Application の翻訳

### 資料
- handbookのページ: https://turbo.hotwired.dev/handbook/installing
- GitHubのページ: https://github.com/hotwired/turbo-site/blob/main/_source/handbook/07_installing.md

## レビュー後にやること
- 英文の削除