### PR TITLE
正式なタイトル名に修正: TurboHandbook -> Turbo Handbook

### DIFF
--- a/layouts/base.html
+++ b/layouts/base.html
@@ -30,7 +30,7 @@ title: Hotwire
         <footer>
           <p class="footer-headline">
             <small>
-              <a href="https://github.com/hotwired/turbo-site/issues/96">DHHの許諾</a>のもと、<a href="https://turbo.hotwired.dev/handbook/introduction">公式のTurboHandbook</a>を<a href="https://github.com/hotwired/turbo-site/commit/59943d962b37a02c1dcb68ebaa1057f713a45975">オリジナル</a>として、翻訳をしています。
+              <a href="https://github.com/hotwired/turbo-site/issues/96">DHHの許諾</a>のもと、<a href="https://turbo.hotwired.dev/handbook/introduction">公式のTurbo Handbook</a>を<a href="https://github.com/hotwired/turbo-site/commit/59943d962b37a02c1dcb68ebaa1057f713a45975">オリジナル</a>として、翻訳をしています。
             </small>
             <br>
             <small>


### PR DESCRIPTION
英語ページのタイトルに合わせて、標題の通り修正してみました! 📝 ✅ 

```html
<title>Turbo Handbook</title>
```

cf. https://turbo.hotwired.dev/handbook/introduction

<img width="847" alt="image" src="https://github.com/everyleaf/hotwire_ja/assets/155807/87c08efb-cb3d-4003-a69c-624361897f94">
