### PR TITLE
今後はFront Matterの order を利用するので残してもらう

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   - 上記は [Front Matter Data](https://www.11ty.dev/docs/data-frontmatter/) と呼ばれるもので、Eleventyでビルドする際に必要な情報です。以下の対応をお願いします
     - permalinkの行は削除してください（本家と階層構造が異なるため）
     - titleやdescriptionがある場合は翻訳してください
+    - orderはそのまま残すようにしてください。これはリファレンスのページの並び順を指定するためのものです
 
 
 # PRの応対について


### PR DESCRIPTION
## 目的
今まではハードコーディングでサイドバーを生成していましたが、今後はcollectionsの機能を利用するためページの並び順を固定する必要があります。
本家同様、Front Matterにorderプロパティを追加してそれを基準にソートする方法が便利なのでそれを踏襲する実装にしました。（基本的には本家と同じ並び順で良いので翻訳ページを作るときにそのまま残していただきたい）
ついては、READMEにorderについての記載がなかったのでそれを追記しました。