### PR TITLE
Dependabot を利用して、GitHub Actions のバージョンを週毎に確認する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Issue
GitHub Actions で Node.js に関するワーニングが出ていた
- https://github.com/everyleaf/hotwire_ja/actions/runs/8242241024

## 対応
GtiHub Actions のバージョンを定期的にあげることで、内部で利用されている Node.js などのバージョンもあげる仕組みを作る