### PR TITLE
[turbo handbook] framesのページの並び順が重複していた

### DIFF
--- a/turbo/handbook/frames.md
+++ b/turbo/handbook/frames.md
@@ -1,8 +1,7 @@
 ---
-order: 04
 title: "Turboフレームを分解する"
 description: "Turbo Framesはページを独立したコンテキストに分解し、それらを遅延ロードできるようにし、インタラクションの範囲を制限します。"
-order: 3
+order: 4
 ---
 
 # Turboフレームを分解する


### PR DESCRIPTION
## なんのためか

frames.md の Front Matterにorderの指定が重複していたため、[buildが失敗している](https://github.com/everyleaf/hotwire_ja/actions/runs/10362147207)。これを直したい

- frames.mdの正しい順序は `order:4` ([本家](https://github.com/hotwired/turbo-site/blob/main/_source/handbook/04_frames.md)) 