### PR TITLE
fix: clean the outputs from Eleventy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "serve": "npm-run-all -s clean build:11ty build:css -p watch:** --silent",
     "publish": "run-s build:**",
-    "clean": "del-cli \"_public/**\"",
+    "clean": "del-cli \"_site\"",
     "build:11ty": "eleventy --pathprefix=hotwire_ja",
     "watch:11ty": "eleventy --serve --quiet",
     "build:css": "sass --style=compressed _assets/css/main.scss _site/assets/main.css",


### PR DESCRIPTION
Because Eleventy's default output dir is not `_public` but `_site`.
- ref: https://www.11ty.dev/docs/config/#output-directory