### PR TITLE
Remove a deprecated warning about markdown-it-anchor permalink option

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,10 +13,11 @@ var md = require('markdown-it')({
 module.exports = function(eleventyConfig) {
   md.use(markdownItAnchor, { // add anchors to headings
     level: '2',
-    permalink: 'true',
-    permalinkClass: 'anchor',
-    permalinkSymbol: '﹟',
-    permalinkBefore: 'true'
+    permalink: markdownItAnchor.permalink.ariaHidden({
+      class: 'anchor',
+      symbol: '#',
+      placement: 'before'
+    }),
   });
   md.use(markdownItToc, { // make a TOC with ${toc}
     level: '2',


### PR DESCRIPTION
Issue

A deprecated warning is raised because the currently specified option is outdated.

```console
% npm run serve
...
Warning: Using deprecated markdown-it-anchor permalink option, see https://github.com/valeriangalliat/markdown-it-anchor#permalinks
...
```

Solution

Update the markdown-it-anchor permalink option to use the current configuration.
ref: https://github.com/valeriangalliat/markdown-it-anchor#permalinks