### PR TITLE
Use sass-migrator to update our stylesheets without `@import` rules

### DIFF
--- a/_assets/css/base/_elements.scss
+++ b/_assets/css/base/_elements.scss
@@ -1,3 +1,5 @@
+@use "mixins";
+
 // scss-lint:disable unknownProperties
 
 * {
@@ -15,24 +17,24 @@ body {
   padding: 0;
   position: relative;
   overflow-x: hidden;
-  color: $color-text;
-  font-family: $serif-stack;
-  font-size: $font-base-small;
+  color: mixins.$color-text;
+  font-family: mixins.$serif-stack;
+  font-size: mixins.$font-base-small;
   font-style: normal;
   font-weight: 400;
   line-height: 1;
 
-  @include media(large) {
-    font-size: $font-base-medium;
+  @include mixins.media(large) {
+    font-size: mixins.$font-base-medium;
   }
 
-  @include media(x-large) {
-    font-size: $font-base-large;
+  @include mixins.media(x-large) {
+    font-size: mixins.$font-base-large;
   }
 }
 
 a {
-  color: $color-text;
+  color: mixins.$color-text;
   font-weight: 550;
   margin: -.2rem;
   padding: .2rem;
@@ -41,27 +43,27 @@ a {
   text-decoration-width: 0.1rem;
 
   &:visited {
-    color: $color-text;
+    color: mixins.$color-text;
   }
 
   @media (hover: hover) {
 
     &:hover {
-      text-decoration-color: $color-accent;
+      text-decoration-color: mixins.$color-accent;
       text-decoration-thickness: 0.2em;
       text-decoration-width: 0.2em;
     }
   }
 
   &:active {
-    color: $color-text;
+    color: mixins.$color-text;
   }
 }
 
 h1, h2, h3 {
   margin-top: 1.5em;
   margin-bottom: 0.75em;
-  font-family: $sans-stack;
+  font-family: mixins.$sans-stack;
   font-weight: 600;
   letter-spacing: -.01em;
   line-height: 1.1em;
@@ -71,19 +73,19 @@ h1, h2, h3 {
 
 h1 {
   margin-top: 2em;
-  font-size: $font-xxx-large;
+  font-size: mixins.$font-xxx-large;
   font-weight: 700;
 }
 
 h2 {
   margin-top: 2.5em;
-  font-size: $font-xx-large;
+  font-size: mixins.$font-xx-large;
   text-align: center;
 }
 
 h3 {
   margin-top: 2.5em;
-  font-size: $font-x-large;
+  font-size: mixins.$font-x-large;
   font-weight: 500;
   letter-spacing: 0.01em;
 }
@@ -118,7 +120,7 @@ blockquote {
   position: relative;
   margin-bottom: 1.5em;
   padding: 0 0 0 2em;
-  border-left: 2px solid $color-text;
+  border-left: 2px solid mixins.$color-text;
   text-align: left;
 
   &:before {
@@ -150,10 +152,10 @@ hr {
 
 code,
 pre {
-  font-family: $mono-stack;
+  font-family: mixins.$mono-stack;
   line-height: 1.25;
   padding:  0 0.1em;
-  background-color: $color-tint;
+  background-color: mixins.$color-tint;
   direction: ltr;
   text-align: left;
   white-space: pre;
@@ -176,9 +178,9 @@ pre {
   margin-top: 0;
   margin-bottom: 2em;
   font-weight: 400;
-  background: $color-tint;
+  background: mixins.$color-tint;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     margin: 0 0 2em 0;
   }
 
@@ -191,7 +193,7 @@ pre {
     bottom: 0;
     right: 0;
     width: 2em;
-    background: linear-gradient(to right, rgba($color-tint, 0), $color-tint);
+    background: linear-gradient(to right, rgba(mixins.$color-tint, 0), mixins.$color-tint);
   }
 }
 
@@ -216,12 +218,12 @@ table {
 }
 
 thead {
-  background-color: $color-tint;
-  font-family: $sans-stack;
+  background-color: mixins.$color-tint;
+  font-family: mixins.$sans-stack;
 }
 
 tr {
-  border-bottom: 0.125em solid $color-tint;
+  border-bottom: 0.125em solid mixins.$color-tint;
 }
 
 th,

--- a/_assets/css/components/_anchor.scss
+++ b/_assets/css/components/_anchor.scss
@@ -1,8 +1,10 @@
+@use "../base/mixins";
+
 .anchor {
   float: left;
   margin: 0 0 0 -1em;
   padding: 0;
-  font-size: $font-x-small;
+  font-size: mixins.$font-x-small;
   text-decoration: none;
   opacity: 0.5;
 }

--- a/_assets/css/components/_button.scss
+++ b/_assets/css/components/_button.scss
@@ -1,27 +1,29 @@
+@use "../base/mixins";
+
 .button {
   transition: font-weight 0.1s ease, clip-path 0.2s ease, background-color 0.2s ease;
   display: inline-block;
   padding: 1em 1.5em;
-  color: $color-text;
-  font-family: $sans-stack;
+  color: mixins.$color-text;
+  font-family: mixins.$sans-stack;
   text-decoration: none;
   text-align: center;
   line-height: normal;
   -webkit-appearance: none;
-  background-color: $color-brand;
+  background-color: mixins.$color-brand;
   border: 0;
   box-shadow: none;
   clip-path: polygon(5% 10%, 46% 1%, 46% 10%, 100% 0, 95% 90%, 31% 100%, 31% 90%, 0% 100%);
 
   &:visited {
-    color: $color-text;
+    color: mixins.$color-text;
   }
 
   @media (hover: hover) {
 
     &:hover {
-      color: $color-text;
-      background-color: $color-accent;
+      color: mixins.$color-text;
+      background-color: mixins.$color-accent;
       cursor: pointer;
       text-decoration: none;
       font-weight: 800;

--- a/_assets/css/components/_docs.scss
+++ b/_assets/css/components/_docs.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins";
+
 // docs layout ////////////////////////////////////////////////////////////
 
 .docs {
@@ -7,11 +9,11 @@
 .docs__content {
   grid-column-start: 2;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     grid-column: 6 / span 8;
   }
 
-  @include media(large) {
+  @include mixins.media(large) {
     grid-column: 5 / span 8;
   }
 
@@ -34,14 +36,14 @@
   text-align: left;
   overflow-y: auto;
 
-  @include media(small) {
+  @include mixins.media(small) {
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 1em 0;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     grid-column: 2 / span 4;
     position: -webkit-sticky;
     position: sticky;
@@ -51,7 +53,7 @@
     padding: 3.25em 0 0 0;
   }
 
-  @include media(large) {
+  @include mixins.media(large) {
     grid-column: 2 / span 3;
   }
 }
@@ -63,7 +65,7 @@
 .docs__screenshot {
   max-width: 100%;
   height: auto;
-  border: 0.2rem solid $color-background;
+  border: 0.2rem solid mixins.$color-background;
   border-radius: 5px;
-  box-shadow: 0 0 1em rgba($color-text, 0.1);
+  box-shadow: 0 0 1em rgba(mixins.$color-text, 0.1);
 }

--- a/_assets/css/components/_grid.scss
+++ b/_assets/css/components/_grid.scss
@@ -1,9 +1,12 @@
+@use "sass:string";
+@use "../base/mixins";
+
 // grid system ////////////////////////////////////////////////////////////////
 .grid {
   display: grid;
   grid-template-columns: 1fr minmax(80vw, 100%) 1fr;
   align-items: start;
-  column-gap: unquote("min(5vw, 4rem)");
+  column-gap: string.unquote("min(5vw, 4rem)");
 
   > .grid {
     grid-column: 1 / -1;
@@ -13,16 +16,16 @@
     grid-column: 2;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     grid-template-columns: 1fr repeat(12, minmax(2rem, 100%)) 1fr;
-    column-gap: unquote("min(3vw, 5rem)");
+    column-gap: string.unquote("min(3vw, 5rem)");
 
     > *:not([class*="grid"]) {
       grid-column: 4 / span 8;
     }
   }
 
-  @include media(x-large) {
+  @include mixins.media(x-large) {
     grid-template-columns: 1fr repeat(12, 7.5rem) 1fr;
     column-gap: 4rem;
   }
@@ -36,7 +39,7 @@
   &--bleed-right { grid-column-end: -1; }
   &--bleed-full { grid-column: 1 / -1; }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     //grid-column: 4 / span 8;
 
     &--span-3 { grid-column-end: span 3; }

--- a/_assets/css/components/_jump.scss
+++ b/_assets/css/components/_jump.scss
@@ -1,19 +1,21 @@
+@use "../base/mixins";
+
 // jump nav ///////////////////////////////////////////////////////////////
 
 .jump {
   width: 100%;
   margin: 0;
   padding: 0 1em;
-  color: $color-background;
-  background-color: $color-brand;
+  color: mixins.$color-background;
+  background-color: mixins.$color-brand;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: $sans-stack;
+  font-family: mixins.$sans-stack;
   text-transform: uppercase;
   font-style: italic;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     justify-content: flex-start;
   }
 }
@@ -44,21 +46,21 @@
   display: inline-block;
   margin: 0;
   padding: 0.5em 0.125em;
-  color: $color-background;
+  color: mixins.$color-background;
   font-weight: 500;
   text-decoration: none;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     padding: 0.125em;
-    font-size: $font-small;
+    font-size: mixins.$font-small;
   }
 
   &:visited {
-    color: $color-background;
+    color: mixins.$color-background;
   }
 
   &:hover {
-    color: $color-accent;
+    color: mixins.$color-accent;
   }
 }
 
@@ -68,7 +70,7 @@
 }
 
 .jump__list-link--active {
-  color: $color-accent !important;
+  color: mixins.$color-accent !important;
   text-decoration: none;
   pointer-events: none;
 }
@@ -81,7 +83,7 @@
 
 .jump__list-info {
 
-  @include media(small) {
+  @include mixins.media(small) {
     clip: rect(1px, 1px, 1px, 1px);
     position: absolute !important;
     height: 1px;

--- a/_assets/css/components/_landing.scss
+++ b/_assets/css/components/_landing.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins";
+
 // scss-lint:disable VendorPrefix
 // intro //////////////////////////////////////////////////////////////////////
 
@@ -5,8 +7,8 @@
   position: relative;
   margin: 0;
   padding: 0;
-  background-color: $color-tint;
-  border-top: 0.4rem solid $color-brand;
+  background-color: mixins.$color-tint;
+  border-top: 0.4rem solid mixins.$color-brand;
 }
 
 .landing-intro__text {
@@ -14,12 +16,12 @@
   z-index: 1;
   margin: 1.75em 0 2em 0;
   text-align: center;
-  color: $color-text;
+  color: mixins.$color-text;
   font-weight: 800;
   line-height: 1.3;
 
-  @include media(medium) {
-    font-size: $font-xxxx-large;
+  @include mixins.media(medium) {
+    font-size: mixins.$font-xxxx-large;
   }
 }
 
@@ -27,7 +29,7 @@
 
 .landing-summary {
   text-align: left;
-  font-size: $font-large;
+  font-size: mixins.$font-large;
 }
 
 .landing-version {
@@ -35,16 +37,16 @@
   position: relative;
   padding: 0;
   margin: -2em 0 5em 0;
-  font-family: $sans-stack;
+  font-family: mixins.$sans-stack;
   font-weight: 600;
   font-style: italic;
-  font-size: $font-small;
+  font-size: mixins.$font-small;
   text-align: center;
 
   > span {
     display: inline-block;
     padding: 1em 2em;
-    background-color: $color-brand;
+    background-color: mixins.$color-brand;
     clip-path: polygon(5% 10%, 46% 1%, 46% 10%, 100% 0, 95% 90%, 31% 100%, 31% 90%, 0% 100%);
   }
 }
@@ -55,7 +57,7 @@
   grid-column: 3/4;
   margin: 0;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     display: flex;
     justify-content: space-between;
     align-items: stretch;
@@ -66,21 +68,21 @@
   display: block;
   margin-bottom: 1em;
   padding: 1.5em 1em;
-  font-family: $sans-stack;
+  font-family: mixins.$sans-stack;
   font-style: italic;
   text-align: center;
   line-height: 1.25;
-  background-color: $color-background;
-  box-shadow: 0 0 2em rgba($color-text, 0.075);
+  background-color: mixins.$color-background;
+  box-shadow: 0 0 2em rgba(mixins.$color-text, 0.075);
   border-radius: 0.5em;
 
-  @include media(small) {
+  @include mixins.media(small) {
     max-width: 20em;
     margin-left: auto;
     margin-right: auto;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     width: 32%;
     margin-bottom: 0;
   }
@@ -91,9 +93,9 @@
   width: 3.75em;
   height: 3.75em;
   margin: 0 auto 1em auto;
-  background-color: $color-brand;
+  background-color: mixins.$color-brand;
 
   .landing-actions__item:hover & {
-    background-color: $color-accent;
+    background-color: mixins.$color-accent;
   }
 }

--- a/_assets/css/components/_nav.scss
+++ b/_assets/css/components/_nav.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins";
+
 // primary nav ////////////////////////////////////////////////////////////
 
 .nav-skip {
@@ -6,7 +8,7 @@
   height: 1px;
   width: 1px;
   overflow: hidden;
-  background-color: $color-background;
+  background-color: mixins.$color-background;
 
   &:hover,
   &:active,
@@ -32,7 +34,7 @@
   }
 
   .logo__icon {
-    fill: $color-brand;
+    fill: mixins.$color-brand;
   }
 
   path {
@@ -42,16 +44,16 @@
   @media (hover: hover) {
 
     &:hover path {
-      fill: $color-accent;
+      fill: mixins.$color-accent;
     }
   }
 }
 
 .nav {
 
-  @include media(small) {
-    @include transform(translate(-100%, 0));
-    @include transition(transform 0.3s ease-in-out);
+  @include mixins.media(small) {
+    @include mixins.transform(translate(-100%, 0));
+    @include mixins.transition(transform 0.3s ease-in-out);
     opacity: 0;
     position: fixed;
     overflow-y: auto;
@@ -64,16 +66,16 @@
     height: 100%;
     z-index: 3000;
     text-align: right;
-    background-color: $color-brand;
+    background-color: mixins.$color-brand;
   }
 
-  @include media(medium) {
-    @include transform(translate(0, 0));
-    @include transition(transform 0s ease-in-out);
+  @include mixins.media(medium) {
+    @include mixins.transform(translate(0, 0));
+    @include mixins.transition(transform 0s ease-in-out);
     margin: 0;
     padding: 0;
     opacity: 1;
-    background-color: $color-background;
+    background-color: mixins.$color-background;
   }
 }
 
@@ -83,9 +85,9 @@
   margin: 1em 0 0 0;
   text-align: right;
   list-style-type: none;
-  border-top: 0.2rem solid $color-brand;
+  border-top: 0.2rem solid mixins.$color-brand;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     text-align: left;
   }
 
@@ -101,11 +103,11 @@
 
 .nav__list--horizontal {
 
-  @include media(small) {
-    font-size: $font-x-large;
+  @include mixins.media(small) {
+    font-size: mixins.$font-x-large;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     display: flex;
     margin: 0;
     border: none;
@@ -121,8 +123,8 @@
   display: block;
   margin: 0.5em 0;
   padding: 0.25em 0;
-  font-size: $font-x-large;
-  font-family: $sans-stack;
+  font-size: mixins.$font-x-large;
+  font-family: mixins.$sans-stack;
   font-weight: 600;
   font-style: italic;
   line-height: 1.25;
@@ -133,9 +135,9 @@
     font-weight: 800;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     line-height: 1.4;
-    font-size: $font-medium;
+    font-size: mixins.$font-medium;
 
     .nav__list--horizontal & {
       padding: 0;
@@ -155,11 +157,11 @@
   display: none;
   list-style-type: none;
   margin: 0;
-  border-right: 0.2rem solid $color-text;
+  border-right: 0.2rem solid mixins.$color-text;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     border-right: 0;
-    border-left: 0.2rem solid $color-text;
+    border-left: 0.2rem solid mixins.$color-text;
   }
 
   &.active {
@@ -176,8 +178,8 @@
   display: block;
   margin: 0;
   padding: 0.5em;
-  font-size: $font-large;
-  font-family: $sans-stack;
+  font-size: mixins.$font-large;
+  font-family: mixins.$sans-stack;
   font-weight: 400;
   line-height: 1.25;
 
@@ -187,16 +189,16 @@
     font-weight: 800;
   }
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     text-align: left;
     margin-bottom: 0.5em;
     padding: 0.25em;
-    font-size: $font-small;
+    font-size: mixins.$font-small;
     line-height: 1.4;
 
     &.active {
-      color: $color-text;
-      background-color: $color-tint;
+      color: mixins.$color-text;
+      background-color: mixins.$color-tint;
       border-radius: 0.125em;
     }
   }
@@ -207,7 +209,7 @@
 }
 
 .nav-checkbox:checked ~ .nav {
-  @include transform(translate(0, 0));
+  @include mixins.transform(translate(0, 0));
   opacity: 1;
 }
 
@@ -217,14 +219,14 @@
   padding: 0.5em 1em;
   cursor: pointer;
   z-index: 2000;
-  font-family: $sans-stack;
-  font-size: $font-large;
+  font-family: mixins.$sans-stack;
+  font-size: mixins.$font-large;
   font-weight: 800;
   text-transform: uppercase;
-  background-color: $color-brand;
+  background-color: mixins.$color-brand;
   border-radius: 0.2rem;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
     display: none;
   }
 
@@ -234,7 +236,7 @@
     top: -0.5rem;
     width: 1.25em;
     height: 0.2rem;
-    background-color: $color-background;
+    background-color: mixins.$color-background;
 
     &::after,
     &::before {
@@ -243,7 +245,7 @@
       display: block;
       width: 1.25em;
       height: 0.2rem;
-      background-color: $color-background;
+      background-color: mixins.$color-background;
     }
 
     &::before {
@@ -259,23 +261,23 @@
 .nav-mobile-button--close {
   margin: 1.5em auto 1.5em auto;
   padding: 0;
-  background-color: $color-brand;
+  background-color: mixins.$color-brand;
 
   span {
     background-color: rgba(0, 0, 0, 0);
 
     &::before,
     &::after {
-      background-color: $color-text;
+      background-color: mixins.$color-text;
       margin-top: 0;
     }
 
     &::before {
-      @include transform(rotate(45deg));
+      @include mixins.transform(rotate(45deg));
     }
 
     &::after {
-      @include transform(rotate(-45deg));
+      @include mixins.transform(rotate(-45deg));
     }
   }
 }

--- a/_assets/css/components/_page.scss
+++ b/_assets/css/components/_page.scss
@@ -1,3 +1,5 @@
+@use "../base/mixins";
+
 // default page layout ////////////////////////////////////////////////////////
 
 .page-header {
@@ -13,7 +15,7 @@
   padding: 3em 0;
   text-align: center;
 
-  @include media(medium) {
+  @include mixins.media(medium) {
 
     &:before {
       content: '';

--- a/_assets/css/main.scss
+++ b/_assets/css/main.scss
@@ -1,14 +1,14 @@
 
-@import "base/mixins",
-"base/elements",
-"components/anchor",
-"components/button",
-"components/jump",
-"components/nav",
-"components/foot",
-"components/page",
-"components/docs",
-"components/landing",
-"components/highlighter",
-"components/callout",
-"components/grid";
+@use "base/mixins";
+@use "base/elements";
+@use "components/anchor";
+@use "components/button";
+@use "components/jump";
+@use "components/nav";
+@use "components/foot";
+@use "components/page";
+@use "components/docs";
+@use "components/landing";
+@use "components/highlighter";
+@use "components/callout";
+@use "components/grid";


### PR DESCRIPTION
## Issue

There are some warning when we run `npm run serve` as follows. Because using `@import` rules is depreacated now.

```console
$ npm run serve
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │ @import "base/mixins",
  │         ^^^^^^^^^^^^^
  ╵
    _assets/css/main.scss 2:9  root stylesheet

Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import
```

## Solution

We can use Sass migrator which is provided by Sass project. This migrator automatically update your stylesheets to use the module system. It will resove the above warnings.

```console
$ npm install -g sass-migrator
$ sass-migrator module --migrate-deps your-entrypoint.scss
```