### PR TITLE
タイトルの並び順の変更

### DIFF
--- a/layouts/base.html
+++ b/layouts/base.html
@@ -8,7 +8,7 @@ title: Hotwire
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ description }}">
     <link rel="stylesheet" href="/assets/main.css">
-    <title>{% if section_title %}{{ section_title }}: {% endif %}{{ title }}</title>
+    <title>{{ title }}{% if section_title %}: {{ section_title }}{% endif %}</title>
   </head>
   <body>
   <nav class="jump">


### PR DESCRIPTION
#104 の対応

ページのタイトルを前、`section_title`のまとまりごとのタイトルを後となるように変更した
