### PR TITLE
タイトルの「ハンドブック」を「Turbo ハンドブック: Hotwire ドキュメント（有志翻訳版）」 に変更

### DIFF
--- a/turbo/handbook/handbook.json
+++ b/turbo/handbook/handbook.json
@@ -3,6 +3,6 @@
     "turbo_handbook"
   ],
   "layout": "base.html",
-  "section_title": "ハンドブック",
+  "section_title": "Hotwire Turbo ハンドブック（翻訳版）",
   "section_code": "turbo_handbook"
 }

--- a/turbo/handbook/handbook.json
+++ b/turbo/handbook/handbook.json
@@ -3,6 +3,6 @@
     "turbo_handbook"
   ],
   "layout": "base.html",
-  "section_title": "Hotwire Turbo ハンドブック（翻訳版）",
+  "section_title": "Turbo ハンドブック: Hotwire ドキュメント（有志翻訳版）",
   "section_code": "turbo_handbook"
 }


### PR DESCRIPTION
#105 の対応

`section_title`の「ハンドブック」を「Turbo ハンドブック: Hotwire ドキュメント（有志翻訳版）」 に変更した