### PR TITLE
jumplistの文言変更&トップへのリンクを本家に飛ばさないようにした

### DIFF
--- a/layouts/base.html
+++ b/layouts/base.html
@@ -13,7 +13,7 @@ title: Hotwire
   <body>
   <nav class="jump">
     <ul class="jump__list">
-      <li><a class="jump__list-link jump__list-link--hotwire" href="https://hotwired.dev">Hotwire:</a></li>
+      <li><a class="jump__list-link jump__list-link--hotwire" href="/">Hotwire ドキュメント（有志翻訳版）:</a></li>
       <li><a class="jump__list-link jump__list-link--active" href="/">Turbo</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
#106 　対応
- ISSUEにある「Hotwireリファレンス」だと階層的に微妙だったので「Hotwire ドキュメント」を採用
- リンクがないのも押した時のユーザー体験としてどうかと思うので、現在のTOPであるTurbo に飛ばしている