### PR TITLE
タイトルの「リファレンス」を「Turbo リファレンス: Hotwire ドキュメント（有志翻訳版）」に変更

### DIFF
--- a/turbo/reference/reference.json
+++ b/turbo/reference/reference.json
@@ -3,6 +3,6 @@
     "turbo_reference"
   ],
   "layout": "base.html",
-  "section_title": "リファレンス",
+  "section_title": "Turbo リファレンス: Hotwire ドキュメント（有志翻訳版）",
   "section_code": "turbo_reference"
 }


### PR DESCRIPTION
#121 の対応
`section_title`の「ハンドブック」を「Turbo リファレンス: Hotwire ドキュメント（有志翻訳版）」 に変更した