### PR TITLE
Add Rake Task for automatic translation diff detection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require_relative "tasks/diff_task"
+
+diff_task = DiffTask.new
+diff_task.define
+
+task default: ["translate:diff"]

--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -70,6 +70,7 @@ class DiffTask
   end
 
   def collect_source_files
+    # e.g. turbo-site/_source/{handbook|reference}/01_introduction.md
     [HANDBOOK_DIR, REFERENCE_DIR].flat_map do |dir|
       Pathname.glob(source_repository_path.join(SOURCE_DIR, dir, "*.md")).map do |source_path|
         SourceFile.new(source_path)
@@ -83,6 +84,7 @@ class DiffTask
   end
 
   def collect_translated_files
+    # e.g. hotwire_ja/turbo/{handbook|reference}/introduction.md
     [HANDBOOK_DIR, REFERENCE_DIR].flat_map do |dir|
       Pathname.glob(translation_repository_path.join(TURBO_DIR, dir, "*.md")).map do |translated_path|
         TranslatedFile.new(translated_path)

--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -1,0 +1,12 @@
+class DiffTask
+  include Rake::DSL
+
+  def define
+    namespace :translate do
+      desc "Show translation diff"
+      task :diff do
+        puts "translate:diff is called."
+      end
+    end
+  end
+end

--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -1,8 +1,9 @@
 require "pathname"
 require "tempfile"
 
-require_relative "translated_file"
 require_relative "source_file"
+require_relative "translated_file"
+require_relative "translation_pr"
 
 class DiffTask
   include Rake::DSL
@@ -23,7 +24,14 @@ class DiffTask
           translated_file = source_file.find_translated_file(translated_files)
           next unless translated_file
 
-          diff_content = diff(source_file, translated_file)
+          source_latest_commit, diff_content = diff(source_file, translated_file)
+          next unless diff_content
+
+          translation_pr = TranslationPr.new(translation_repository_path,
+                                             translated_file,
+                                             diff_content,
+                                             source_latest_commit)
+          translation_pr.create_or_update
         end
       end
     end
@@ -34,6 +42,7 @@ class DiffTask
   def diff(source_file, translated_file)
     translated_commit = translated_file.front_matter[:commit]
     return unless translated_commit
+    return if translated_commit == source_latest_commit
 
     Tempfile.open("diff.txt") do |tempfile|
       sh("git",
@@ -43,7 +52,7 @@ class DiffTask
          "#{translated_commit}..#{source_latest_commit}",
          source_file.path.to_s,
          {out: tempfile})
-      tempfile.open.read
+      [source_latest_commit, tempfile.open.read]
     end
   end
 

--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -1,12 +1,61 @@
+require "pathname"
+require_relative "translated_file"
+require_relative "source_file"
+
 class DiffTask
   include Rake::DSL
+
+  HANDBOOK_DIR = "handbook"
+  REFERENCE_DIR = "reference"
+  SOURCE_DIR = "_source"
+  TURBO_DIR = "turbo"
 
   def define
     namespace :translate do
       desc "Show translation diff"
       task :diff do
-        puts "translate:diff is called."
+        source_files = collect_source_files
+        translated_files = collect_translated_files
+
+        source_files.each do |source_file|
+          translated_file = source_file.find_translated_file(translated_files)
+          next unless translated_file
+          pp translated_file
+        end
       end
     end
+  end
+
+  private
+
+  def collect_source_files
+    [HANDBOOK_DIR, REFERENCE_DIR].flat_map do |dir|
+      Pathname.glob(source_repository_path.join(SOURCE_DIR, dir, "*.md")).map do |source_path|
+        SourceFile.new(source_path)
+      end
+    end
+  end
+
+  def source_repository_path
+    path = Pathname(turbo_site_repository)
+    path.expand_path
+  end
+
+  def collect_translated_files
+    [HANDBOOK_DIR, REFERENCE_DIR].flat_map do |dir|
+      Pathname.glob(translation_repository_path.join(TURBO_DIR, dir, "*.md")).map do |translated_path|
+        TranslatedFile.new(translated_path)
+      end
+    end
+  end
+
+  def translation_repository_path
+    Pathname(__dir__).parent.expand_path
+  end
+
+  def turbo_site_repository
+    repository = ENV["TURBO_SITE_REPOSITORY"]
+    raise "Specify TURBO_SITE_REPOSITORY environment variable" if repository.nil?
+    repository
   end
 end

--- a/tasks/source_file.rb
+++ b/tasks/source_file.rb
@@ -1,0 +1,21 @@
+require "pathname"
+
+class SourceFile
+  attr_reader :path
+
+  def initialize(path)
+    @path = Pathname.new(path)
+  end
+
+  def normalized_path
+    normalized_basename = path.basename.sub(/^\d+_/, "")
+    path.dirname + normalized_basename
+  end
+
+  def find_translated_file(files)
+    dir, basename = normalized_path.to_s.split("/").last(2)
+    files.find do |file|
+      file.path.to_s.match?(/\/#{dir}\/#{basename}\z/)
+    end
+  end
+end

--- a/tasks/source_file.rb
+++ b/tasks/source_file.rb
@@ -8,11 +8,15 @@ class SourceFile
   end
 
   def normalized_path
+    # turbo-site/_source/{handbook|reference}/01_introduction.md
+    # -> turbo-site/_source/{handbook|reference}/introduction.md
     normalized_basename = path.basename.sub(/^\d+_/, "")
     path.dirname + normalized_basename
   end
 
   def find_translated_file(files)
+    # turbo-site/_source/handbook/introduction.md
+    # -> handbook, introduction.md
     dir, basename = normalized_path.to_s.split("/").last(2)
     files.find do |file|
       file.path.to_s.match?(/\/#{dir}\/#{basename}\z/)

--- a/tasks/translated_file.rb
+++ b/tasks/translated_file.rb
@@ -37,6 +37,8 @@ class TranslatedFile
   end
 
   def parse_metadata
+    # hotwire_ja/turbo/handbook/introduction.md
+    # -> turbo, handbook, introduction.md
     project, category, filename = path.to_s.split("/").last(3)
     topic = filename.sub(".md", "")
     [project, category, topic]

--- a/tasks/translated_file.rb
+++ b/tasks/translated_file.rb
@@ -1,0 +1,25 @@
+require "pathname"
+require "yaml"
+
+class TranslatedFile
+  attr_reader :path, :front_matter
+
+  def initialize(path)
+    @path = Pathname.new(path)
+    @front_matter = parse_front_matter
+  end
+
+  private
+
+  FRONT_MATTER_REGEXP = /\A---\s*\n(.*?)\n---\s*\n/m
+
+  def parse_front_matter
+    content = path.read
+    front_matter_section = content.match(FRONT_MATTER_REGEXP)[0]
+    if front_matter_section
+      YAML.safe_load(front_matter_section, symbolize_names: true)
+    else
+      {}
+    end
+  end
+end

--- a/tasks/translated_file.rb
+++ b/tasks/translated_file.rb
@@ -2,11 +2,25 @@ require "pathname"
 require "yaml"
 
 class TranslatedFile
-  attr_reader :path, :front_matter
+  attr_reader :path, :project, :category, :topic
 
   def initialize(path)
     @path = Pathname.new(path)
     @front_matter = parse_front_matter
+    @project, @category, @topic = parse_metadata
+  end
+
+  def content
+    path.read
+  end
+
+  def front_matter
+    parse_front_matter
+  end
+
+  def update_commit_hash(new_commit)
+    updated_content = content.sub(/(commit:\s*")[^"]+(")/, "\\1#{new_commit}\\2")
+    path.write(updated_content)
   end
 
   private
@@ -14,12 +28,17 @@ class TranslatedFile
   FRONT_MATTER_REGEXP = /\A---\s*\n(.*?)\n---\s*\n/m
 
   def parse_front_matter
-    content = path.read
     front_matter_section = content.match(FRONT_MATTER_REGEXP)[0]
     if front_matter_section
       YAML.safe_load(front_matter_section, symbolize_names: true)
     else
       {}
     end
+  end
+
+  def parse_metadata
+    project, category, filename = path.to_s.split("/").last(3)
+    topic = filename.sub(".md", "")
+    [project, category, topic]
   end
 end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -60,6 +60,7 @@ class TranslationPr
       "updated translation"
   end
 
+  # Use '~~~' because commit diff might include '```'.
   def generate_description(diff)
 <<-DESCRIPTION
 #{DIFF_START}
@@ -104,6 +105,8 @@ DESCRIPTION
       [nil, nil]
     else
       pr_info = JSON.parse(pr_raw_info, symbolize_names: true)
+      # Closed PR could be referenced by `gh pr view` command if there is no
+      # open PR which has the same branch name.
       return [nil, nil] if pr_info[:closed]
       [pr_info[:title], pr_info[:body]]
     end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -1,0 +1,146 @@
+require "json"
+require "rake"
+
+class TranslationPr
+  include Rake::FileUtilsExt
+
+  def initialize(repository_path, translated_file, diff_content, source_latest_commit)
+    @repository_path = repository_path
+    @translated_file = translated_file
+    @diff_content = diff_content
+    @source_latest_commit = source_latest_commit
+  end
+
+  def create_or_update
+    current_title, current_description = find_existed_pr
+    Dir.chdir(repository_path) do
+      if current_title && current_description
+        update_pr(branch,
+                  update_description(current_description, diff_content),
+                  source_latest_commit)
+      else
+        create_pr(branch,
+                  title,
+                  generate_description(diff_content),
+                  source_latest_commit)
+      end
+    end
+  end
+
+  private
+
+  attr_reader :translated_file, :repository_path, :diff_content, :source_latest_commit
+
+  DIFF_START = "## Diff (Please don't change this section. It will be automatically updated.)"
+  DIFF_END = "<!-- Please write your description under here. -->"
+
+  def repo
+    "#{onwer}/#{repository}"
+  end
+
+  def owner
+    ENV["TRANSLATED_OWNER"] || "everyleaf"
+  end
+
+  def repository
+    ENV["TRANSLATED_REPOSIOTRY"] || "hotwire_ja"
+  end
+
+  def branch
+    "update-translation-" +
+      "#{translated_file.project}-" +
+      "#{translated_file.category}-" +
+      "#{translated_file.topic}"
+  end
+
+  def title
+    "#{translated_file.project} " +
+      "#{translated_file.category} " +
+      "#{translated_file.topic}: " +
+      "updated translation"
+  end
+
+  def generate_description(diff)
+<<-DESCRIPTION
+#{DIFF_START}
+
+~~~diff
+#{diff}
+~~~
+
+#{DIFF_END}
+
+DESCRIPTION
+  end
+
+  def update_description(description, diff)
+    lines = description.lines
+    diff_start = lines.index { |line| line.strip == DIFF_START }
+    diff_end = lines.index { |line| line.strip == DIFF_END }
+
+    if diff_start && diff_end && diff_start < diff_end
+      before_diffs = lines[0...diff_start].join
+      after_diffs = lines[(diff_end).next..-1].join
+
+      before_diffs + generate_description(diff) + after_diffs
+    else
+      generate_description(diff)
+    end
+  end
+
+  def find_existed_pr
+    pr_raw_info = Tempfile.open("pr.json") do |pr|
+      sh("gh",
+         "pr",
+         "view",
+         branch,
+         "--json", "closed,title,body",
+         "--repo", repo,
+         {out: pr}
+      )
+      pr.open.read
+    end
+    if pr_raw_info.empty?
+      [nil, nil]
+    else
+      pr_info = JSON.parse(pr_raw_info, symbolize_names: true)
+      return [nil, nil] if pr_info[:closed]
+      [pr_info[:title], pr_info[:body]]
+    end
+  end
+
+  def commit_latest_hash(source_latest_commit)
+    translated_file.update_commit_hash(source_latest_commit)
+    sh("git", "add", translated_file.path.to_s)
+    sh("git",
+       "commit",
+       "-m",
+       "updated translation target commit")
+  end
+
+  def update_pr(branch, description, source_latest_commit)
+    sh("git", "fetch")
+    sh("git", "switch", "-c", branch, "origin/#{branch}")
+    commit_latest_hash(source_latest_commit)
+    sh("git", "push", "origin", branch)
+    sh("gh",
+       "pr",
+       "edit",
+       "--body", description,
+       "--repo", repo)
+  end
+
+  def create_pr(branch, title, description, source_latest_commit)
+    sh("git", "switch", "-c", branch)
+    commit_latest_hash(source_latest_commit)
+    sh("git", "push", "origin", branch)
+    sh("gh",
+       "pr",
+       "create",
+       "--title", title,
+       "--body", description,
+       "--base", "auto-translations-update",
+       "--head", branch,
+       "--repo", repo)
+  end
+end


### PR DESCRIPTION
GitHub: GH-130

今回の変更では、翻訳元である`hotwired/turbo-site`との差分を自動検出し、内容を差分として PR に反映する仕組みを実装しました。これにより、翻訳者は翻訳対象ファイルの変更点を確認するだけで済み、手動でのコミットハッシュ比較や差分検出作業が不要となります。

## やったこと

- **対象ファイルの収集**: [532b914](https://github.com/everyleaf/hotwire_ja/pull/131/commits/532b914338e867fd0ca4f4bc4662161917a4cc72): 翻訳元のソースファイルと翻訳ファイルを収集します。
- **差分検出機能の追加**: [fd8b692](https://github.com/everyleaf/hotwire_ja/pull/131/commits/fd8b692e546056a4c3e1935e3fb6d5fae05b42ad) : ソースファイルと翻訳ファイルの対応付けを行い、差分が存在する場合は翻訳元の最新のコミットハッシュと翻訳ファイル内の共に差分内容を取得します。
- **PR作成処理の自動化**: [2adb52d](https://github.com/everyleaf/hotwire_ja/pull/131/commits/2adb52d40d8ff55ab19e2a06771f4298d808d77f): 差分内容を含むPRを作成します。（または既存PRが存在する場合は内容を更新します。）

<details>
<summary>大まかなフローチャート</summary>

```mermaid
flowchart TD
    A[Start: rake translate:diff] --> B[Collect Source Files]
    B --> C[Collect Translated Files]
    C --> D{For each source file}
    D --> E[Find matching translated file]
    E --> F{Translation exists?}
    F -->|No| D
    F -->|Yes| G[Get translated commit hash]
    G --> H{Needs update?}
    H -->|No| D
    H -->|Yes| I[Generate diff between commits]
    I --> J[Check for existing PR]
    J --> K{PR exists?}
    K -->|Yes| L[Update PR with new diff]
    K -->|No| M[Create new PR]
    L --> N[Update commit hash in translated file]
    M --> N
    N --> D
```

</details>

## やってないこと

差分を閲覧できるURLを生成すること
- PRの差分が分かりづらくなるかなと考え、後続のPRで対応していきます。

## 動作確認方法

### 事前準備

```console
$ export TURBO_SITE_REPOSITORY="$(pwd)/turbo-site" && git clone git@github.com:hotwired/turbo-site.git "$TURBO_SITE_REPOSITORY"
$ TRANSLATED_OWNER="otegami" # please specify your github account name
$ TRANSLATED_REPOSIOTRY="hotwire_ja" # Please specify your forked repository
```

翻訳した時の対象のcommitを任意のファイルに追加してください。

```console
$ git diff
diff --git a/turbo/handbook/page_refreshes.md b/turbo/handbook/page_refreshes.md
index 1476476..30c4a06 100644
--- a/turbo/handbook/page_refreshes.md
+++ b/turbo/handbook/page_refreshes.md
@@ -2,6 +2,7 @@
 title: "モーフィングによるスムーズなページリフレッシュ"
 description: "Turbo はモーフィングとスクロール位置の保存によってスムースなページの更新を可能にします"
 order: 3
+commit: "0b2c287"
 ---
 
 # モーフィングによるスムーズなページリフレッシュ
$ git add turbo/handbook/page_refreshes.md
$ git commit -m 'debug: how it works'
```

### 動作確認

次のコマンドで翻訳の差分が作成されます。
```console
$ rake
```