### PR TITLE
ci translation-diff-monitor: add missing Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 _site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"


### PR DESCRIPTION
The following error happened because we forgot to add Gemfile at GH-135.

```
  bundle
  shell: /usr/bin/bash -e {0}
  env:
    TURBO_SITE_REPOSITORY: /home/runner/work/hotwire_ja/hotwire_ja/turbo-site
Could not locate Gemfile
Error: Process completed with exit code 10.
```