### PR TITLE
turbo handbook drive: remove duplicated table of contents

### DIFF
--- a/turbo/handbook/drive.md
+++ b/turbo/handbook/drive.md
@@ -15,8 +15,6 @@ ${toc}
 <details>
 <summary>原文</summary>
 
-# Navigate with Turbo Drive
-
 Turbo Drive is the part of Turbo that enhances page-level navigation. It watches for link clicks and form submissions, performs them in the background, and updates the page without doing a full reload. It's the evolution of a library previously known as [Turbolinks](https://github.com/turbolinks/turbolinks).
 
 </details>
@@ -33,8 +31,6 @@ Turbo ドライブは、ページ・ナビゲーションを、ある*アクシ�
 
 <details>
 <summary>原文</summary>
-
-## Page Navigation Basics
 
 Turbo Drive models page navigation as a *visit* to a *location* (URL) with an *action*.
 
@@ -88,8 +84,6 @@ Turbo.visit("/edit", { action: "replace" })
 <details>
 <summary>原文</summary>
 
-## Application Visits
-
 Application visits are initiated by clicking a Turbo Drive-enabled link, or programmatically by calling [`Turbo.visit(location)`](/reference/drive#turbodrivevisit).
 
 An application visit always issues a network request. When the response arrives, Turbo Drive renders its HTML and completes the visit.
@@ -141,8 +135,6 @@ Applications using the Turbo Drive [iOS adapter](https://github.com/hotwired/tur
 <details>
 <summary>原文</summary>
 
-## Restoration Visits
-
 Turbo Drive automatically initiates a restoration visit when you navigate with the browser’s Back or Forward buttons. Applications using the [iOS](https://github.com/hotwired/turbo-ios) or [Android](https://github.com/hotwired/turbo-android) adapters initiate a restoration visit when moving backward in the navigation stack.
 
 ![Restore visit action](https://s3.amazonaws.com/turbolinks-docs/images/restore.svg)
@@ -166,8 +158,6 @@ Application visits can be canceled before they start, regardless of whether they
 
 <details>
 <summary>原文</summary>
-
-## Canceling Visits Before They Start
 
 Application visits can be canceled before they start, regardless of whether they were initiated by a link click or a call to [`Turbo.visit`](/reference/drive#turbovisit).
 
@@ -197,8 +187,6 @@ addEventListener("turbo:before-render", (event) => {
 
 <details>
 <summary>原文</summary>
-
-## Custom Rendering
 
 Applications can customize the rendering process by adding a document-wide `turbo:before-render` event listener and overriding the `event.detail.render` property.
 
@@ -236,8 +224,6 @@ document.addEventListener("turbo:before-render", async (event) => {
 
 <details>
 <summary>原文</summary>
-
-## Pausing Rendering
 
 Applications can pause rendering and make additional preparations before continuing.
 
@@ -277,8 +263,6 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
-## Pausing Requests
-
 Application can pause request and make additional preparation before it will be executed.
 
 Listen for the `turbo:before-fetch-request` event to be notified when a request is about to start, and pause it using `event.preventDefault()`. Once the preparation is done continue request by calling `event.detail.resume()`.
@@ -310,8 +294,6 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
-## Performing Visits With a Different Method
-
 By default, link clicks send a `GET` request to your server. But you can change this with `data-turbo-method`:
 
 ```html
@@ -335,8 +317,6 @@ You should consider that for accessibility reasons, it's better to use actual fo
 
 <details>
 <summary>原文</summary>
-
-## Requiring Confirmation for a Visit
 
 Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confirmation will be required for a visit to proceed.
 
@@ -391,8 +371,6 @@ Turbo.session.drive = false
 
 <details>
 <summary>原文</summary>
-
-## Disabling Turbo Drive on Specific Links or Forms
 
 Turbo Drive can be disabled on a per-element basis by annotating the element or any of its ancestors with `data-turbo="false"`.
 
@@ -458,8 +436,6 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
-## View transitions
-
 In [browsers that support](https://caniuse.com/?search=View%20Transition%20API) the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) Turbo can trigger view transitions when navigating between pages.
 
 Turbo triggers a view transition when both the current and the next page have this meta tag:
@@ -516,8 +492,6 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
-## Displaying Progress
-
 During Turbo Drive navigation, the browser will not display its native progress indicator. Turbo Drive installs a CSS-based progress bar to provide feedback while issuing a request.
 
 The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load. (You can change this delay with the [`Turbo.setProgressBarDelay`](/reference/drive#turbodrivesetprogressbardelay) method.)
@@ -564,8 +538,6 @@ In tandem with the progress bar, Turbo Drive will also toggle the [`[aria-busy]`
 <details>
 <summary>原文</summary>
 
-## Reloading When Assets Change
-
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. However, if CSS or JavaScript change, that merge would evaluate them on top of the existing one. Typically, this would lead to undesirable conflicts. In such cases, it's necessary to fetch a completely new document through a standard, non-Ajax request.
 
 To accomplish this, just annotate those asset elements with `data-turbo-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
@@ -600,8 +572,6 @@ To accomplish this, just annotate those asset elements with `data-turbo-track="r
 
 <details>
 <summary>原文</summary>
-
-## Removing Assets When They Change
 
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. When a page depends on external assets like CSS stylesheets that other pages do not, it can be useful to remove them when navigating away from the page.
 
@@ -638,8 +608,6 @@ Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` migh
 <details>
 <summary>原文</summary>
 
-## Ensuring Specific Pages Trigger a Full Reload
-
 You can ensure visits to a certain page will always trigger a full reload by including a `<meta name="turbo-visit-control">` element in the page’s `<head>`.
 
 ```html
@@ -671,8 +639,6 @@ Turbo ドライブは同じオリジンでのURLのみをロード対象とし�
 
 <details>
 <summary>原文</summary>
-
-## Setting a Root Location
 
 Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
 
@@ -722,8 +688,6 @@ addEventListener("turbo:submit-start", ({ target }) => {
 <details>
 <summary>原文</summary>
 
-## Form Submissions
-
 Turbo Drive handles form submissions in a manner similar to link clicks. The key difference is that form submissions can issue stateful requests using the HTTP POST method, while link clicks only ever issue stateless HTTP GET requests.
 
 Throughout a submission, Turbo Drive will dispatch a series of [events][] that
@@ -771,8 +735,6 @@ Turbo が POST リクエストに通常の200ステータスの応答を許さ�
 <details>
 <summary>原文</summary>
 
-## Redirecting After a Form Submission
-
 After a stateful request from a form submission, Turbo Drive expects the server to return an [HTTP 303 redirect response](https://en.wikipedia.org/wiki/HTTP_303), which it will then follow and use to navigate and update the page without reloading.
 
 The exception to this rule is when the response is rendered with either a 4xx or 5xx status code. This allows form validation errors to be rendered by having the server respond with `422 Unprocessable Content` and a broken server to display a "Something Went Wrong" screen on a `500 Internal Server Error`.
@@ -789,8 +751,6 @@ If the form submission is a GET request, you may render the directly rendered re
 
 <details>
 <summary>原文</summary>
-
-## Streaming After a Form Submission
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
 
@@ -866,8 +826,6 @@ function hasSlowInternet() {
 
 <details>
 <summary>原文</summary>
-
-## Prefetching Links on Hover
 
 Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
 
@@ -957,8 +915,6 @@ function hasSlowInternet() {
 <details>
 <summary>原文</summary>
 
-## Preload Links Into the Cache
-
 Preload links into Turbo Drive's cache using the [data-turbo-preload][] boolean attribute.
 
 This will make page transitions feel lightning fast by providing a preview of a page even before the first visit. Use it to preload the most important pages in your application. Avoid over usage, as it will lead to loading content that is not needed.
@@ -1026,8 +982,6 @@ It also dovetails nicely with pages that leverage [Eager-Loading Frames](/refere
 
 <details>
 <summary>原文</summary>
-
-## Ignored Paths
 
 Paths with a `.` in the last level of a path/URL will not be handled by Turbo unless they end in a file extension `.htm`, `.html`, `.xhtml`, or `.php`. Turbo will ignore forms and links that target these paths. The quickest way to get Turbo to target these paths is to add a `/` at the end of the URL. Examples of forms that would be ignored:
 


### PR DESCRIPTION
The translated document’s table of contents included both Japanese and English headings, leading to duplicate entries.
Removed the English section heading so that only the Japanese headings appear in the table of contents.