### PR TITLE
ci translation-diff-monitor: add diff url

### DIFF
--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -70,6 +70,8 @@ class TranslationPr
 #{diff}
 ~~~
 
+#{diff_url}
+
 #{DIFF_END}
 
 DESCRIPTION
@@ -88,6 +90,13 @@ DESCRIPTION
     else
       generate_description(diff)
     end
+  end
+
+  def diff_url
+    base_url = "https://github.com/hotwired/turbo-site/compare/"
+    compared_commits =
+      "#{translated_file.front_matter[:commit]}..#{source_latest_commit}"
+    base_url + compared_commits
   end
 
   def find_existed_pr


### PR DESCRIPTION
GitHub: GH-130

This change includes GitHub compare URL in translation PR description as a reference.