### PR TITLE
Stimulus Handbookのdetails表示調整

### DIFF
--- a/stimulus/handbook/building-something-real.md
+++ b/stimulus/handbook/building-something-real.md
@@ -9,7 +9,9 @@ order: 3
 <a href="/stimulus/handbook/hello-stimulus/">Hello, Stimulus</a>の章で、はじめてコントローラを実装し、 Stimulus が HTML と JavaScript をどのように接続するかを学びました。 次は、Basecamp で使われているコントローラを再現して、実際のアプリケーションで使えるものを見てみましょう。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+# Building Something Real
 
 We’ve implemented our first controller and learned how Stimulus connects HTML to JavaScript. Now let’s take a look at something we can use in a real application by recreating a controller from Basecamp.
 </details>
@@ -25,7 +27,10 @@ BasecampのUIには、以下のようなボタンがよく見られます：
 ウェブプラットフォームには<a href="https://www.w3.org/TR/clipboard-apis/" target="_blank">システムのクリップボードにアクセスするAPI</a>がありますが、それを行うHTML要素はありません。「クリップボードにコピー」ボタンを実装するには、JavaScriptを使う必要があります。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Wrapping the DOM Clipboard API
+
 Scattered throughout Basecamp’s UI are buttons like these:
 
 Screenshot showing a text field with an email address inside and a ”Copy to clipboard“ button to the right
@@ -48,7 +53,10 @@ The web platform has an API for accessing the system clipboard, but there’s no
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Implementing a Copy Button
+
 Let’s say we have an app which allows us to grant someone else access by generating a PIN for them. It would be convenient if we could display that generated PIN alongside a button to copy it to the clipboard for easy sharing.
 
 Open public/index.html and replace the contents of `<body>` with a rough sketch of the button:
@@ -82,7 +90,10 @@ export default class extends Controller {
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Setting Up the Controller
+
 Next, create src/controllers/clipboard_controller.js and add an empty method copy():
 
 ```javascript
@@ -134,7 +145,10 @@ export default class extends Controller {
 
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Defining the Target
+
 We’ll need a reference to the text field so we can select its contents before invoking the clipboard API. Add data-clipboard-target="source" to the text field:
 
 ```html
@@ -151,7 +165,7 @@ export default class extends Controller {
 }
 ```
 
-> ## What’s With That static targets Line?
+> ### What’s With That static targets Line?
 >
 > When Stimulus loads your controller class, it looks for target name strings in a static array called targets. For each target name in the array, Stimulus adds three new properties to your controller. Here, our "source" target name becomes the following properties:
 >
@@ -201,7 +215,10 @@ copy() {
 ページを際読み込みし、コピーボタンをクリックしましょう。 次にテキストエディタに戻り、ペーストします。 PINコードの「1234」が表示されるはずです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Connecting the Action
+
 Now we’re ready to hook up the Copy button.
 
 We want a click on the button to invoke the copy() method in our controller, so we’ll add data-action="clipboard#copy":
@@ -259,7 +276,10 @@ Load the page in your browser and click the Copy button. Then switch back to you
 ページをリロードし、両方のボタンが機能することを確認しましょう。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Stimulus Controllers are Reusable
+
 So far we’ve seen what happens when there’s one instance of a controller on the page at a time.
 
 It’s not unusual to have multiple instances of a controller on the page simultaneously. For example, we might want to display a list of PINs, each with its own Copy button.
@@ -308,7 +328,10 @@ PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Actions and Targets Can Go on Any Kind of Element
+
 Now let’s add one more PIN field. This time we’ll use a Copy link instead of a button:
 
 ```html
@@ -342,7 +365,10 @@ PIN: <textarea data-clipboard-target="source" readonly>3737</textarea>
 次は、コントローラの設計を少し変更するだけで、より堅牢な実装ができることを見てみましょう。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Wrap-Up and Next Steps
+
 In this chapter we looked at a real-life example of wrapping a browser API in a Stimulus controller. We saw how multiple instances of the controller can appear on the page at once, and we explored how actions and targets keep your HTML and JavaScript loosely coupled.
 
 Now let’s see how small changes to the controller’s design can lead us to a more robust implementation.

--- a/stimulus/handbook/designing-for-resilience.md
+++ b/stimulus/handbook/designing-for-resilience.md
@@ -15,7 +15,10 @@ order: 4
 一般的にプログレッシブ・エンハンスメントと呼ばれるこの弾力的なアプローチは、基本的な機能をHTMLとCSSで実装し、その基本的なエクスペリエンスに対する段階的なアップグレードをCSSとJavaScriptでレイヤー化します。 そして基礎となるテクノロジーがブラウザでサポートされるようになったときにそのアップグレードを段階的に提供するのです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+# Designing For Resilience
+
 Although the clipboard API is well-supported in current browsers, we might still expect to have a small number of people with older browsers using our application.
 
 We should also expect people to have problems accessing our application from time to time. For example, intermittent network connectivity or CDN availability could prevent some or all of our JavaScript from loading.
@@ -81,7 +84,10 @@ connect() {
 これでPINフィールドを段階的に強化することができました。 コピーボタンの初期状態は非表示で、JavaScriptがクリップボードAPIのサポートを検出したときだけ表示されるようになります。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Progressively Enhancing the PIN Field
+
 Let’s look at how we can progressively enhance our PIN field so that the Copy button is invisible unless it’s supported by the browser. That way we can avoid showing someone a button that doesn’t work.
 
 We’ll start by hiding the Copy button in CSS. Then we’ll feature-test support for the Clipboard API in our Stimulus controller. If the API is supported, we’ll add a class name to the controller element to reveal the button.
@@ -143,7 +149,10 @@ We have progressively enhanced the PIN field: its Copy button’s baseline state
 次は Stimulus コントローラでどのように状態を管理するかについて学びましょう。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Wrap-Up and Next Steps
+
 In this chapter we gently modified our clipboard controller to be resilient against older browsers and degraded network conditions.
 
 Next, we’ll learn about how Stimulus controllers manage state.

--- a/stimulus/handbook/hello-stimulus.md
+++ b/stimulus/handbook/hello-stimulus.md
@@ -9,7 +9,10 @@ order: 2
 Stimulus がどのように機能するかを学ぶ最良の方法は、簡単なコントローラを作ることです。この章ではその方法を紹介します。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+# Hello, Stimulus
+
 The best way to learn how Stimulus works is to build a simple controller. This chapter will show you how.
 </details>
 
@@ -35,8 +38,10 @@ $ yarn start
 (`stimulus-starter`プロジェクトは依存関係の管理にYarnパッケージ・マネージャーを使用しているので、最初にYarnパッケージ・マネージャーがインストールされていることを確認してください)
 
 <details>
-    <summary>原文</summary>
-Prerequisites
+<summary>原文</summary>
+
+## Prerequisites
+
 To follow along, you’ll need a running copy of the stimulus-starter project, which is a preconfigured blank slate for exploring Stimulus.
 
 We recommend remixing stimulus-starter on Glitch so you can work entirely in your browser without installing anything:
@@ -75,7 +80,10 @@ Then visit http://localhost:9000/ in your browser.
 ブラウザでページをリロードすると、テキストフィールドとボタンが表示されるはずです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## It All Starts With HTML
+
 Let’s begin with a simple exercise using a text field and a button. When you click the button, we’ll display the value of the text field in the console.
 
 Every Stimulus project starts with HTML. Open public/index.html and add the following markup just after the opening <body> tag:
@@ -106,7 +114,10 @@ export default class extends Controller {
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Controllers Bring HTML to Life
+
 At its core, Stimulus’s purpose is to automatically connect DOM elements to JavaScript objects. Those objects are called controllers.
 
 Let’s create our first controller by extending the framework’s built-in Controller class. Create a new file named hello_controller.js in the src/controllers/ folder. Then place the following code inside:
@@ -135,7 +146,10 @@ export default class extends Controller {
 識別子は要素とコントローラの間のリンクの役割を果たします。 この場合、識別子`hello`はStimulusにコントローラクラスのインスタンスを`hello_controller.js`に作成するよう指示します。 コントローラの自動ロードの仕組みについては、<a href="/stimulus/handbook/installing/">インストールガイド</a>を参照してください。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Identifiers Link Controllers With the DOM
+
 Next, we need to tell Stimulus how this controller should be connected to our HTML. We do this by placing an identifier in the data-controller attribute on our `div`:
 
 ```html
@@ -170,7 +184,10 @@ export default class extends Controller {
 ページを再度読み込み、開発者コンソールを開いてください。「Hello, Stimulus！」と表示され、その後に `<div>` が表示されるはずです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Is This Thing On?
+
 Reload the page in your browser and you’ll see that nothing has changed. How do we know whether our controller is working or not?
 
 One way is to put a log statement in the connect() method, which Stimulus calls each time a controller is connected to the document.
@@ -230,7 +247,10 @@ export default class extends Controller {
 ブラウザでページを読み込み、開発者コンソールを開いてください。Greet」ボタンをクリックすると、ログメッセージが表示されるはずです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Actions Respond to DOM Events
+
 Now let’s see how to change the code so our log message appears when we click the “Greet” button instead.
 
 Start by renaming connect() to greet():
@@ -257,7 +277,7 @@ To connect our action method to the button’s click event, open public/index.ht
 </div>
 ```
 
-> ﹟Action Descriptors Explained
+> ### Action Descriptors Explained
 >
 > The data-action value click->hello#greet is called an action descriptor. This particular descriptor says:
 >
@@ -305,7 +325,9 @@ export default class extends Controller {
 次にブラウザでページをリロードし、開発者コンソールを開きます。 入力フィールドにあなたの名前を入力し、「Greet」ボタンをクリックしてください。 Hello world！
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Targets Map Important Elements To Controller Properties
 
 We’ll finish the exercise by changing our action to say hello to whatever name we’ve typed in the text field.
 
@@ -366,7 +388,10 @@ export default class extends Controller {
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Controllers Simplify Refactoring
+
 We’ve seen that Stimulus controllers are instances of JavaScript classes whose methods can act as event handlers.
 
 That means we have an arsenal of standard refactoring techniques at our disposal. For example, we can clean up our greet() method by extracting a name getter:
@@ -398,7 +423,10 @@ export default class extends Controller {
 
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Wrap-Up and Next Steps
+
 Congratulations—you’ve just written your first Stimulus controller!
 
 We’ve covered the framework’s most important concepts: controllers, actions, and targets. In the next chapter, we’ll see how to put those together to build a real-life controller taken right from Basecamp.

--- a/stimulus/handbook/installing.md
+++ b/stimulus/handbook/installing.md
@@ -9,7 +9,9 @@ order: 7
 アプリケーションにStimulusをインストールするには、JavaScriptのバンドルに`@hotwired/stimulus` npm パッケージを追加します。あるいはバンドラーを利用してない場合は、`<script type="module">`タグを使ってstimulus.js をインポートしてください。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+# Installing Stimulus in Your Application
 
 To install Stimulus in your application, add the @hotwired/stimulus npm package to your JavaScript bundle. Or, import stimulus.js in a `<script type="module">` tag.
 </details>
@@ -18,13 +20,7 @@ To install Stimulus in your application, add the @hotwired/stimulus npm package 
 
 Stimulus for Railsをimport-mapsと一緒に使用している場合、何もせずとも自動的に`app/javascript/controllers`からすべてのコントローラファイルを読み込むようになります。
 
-<details>
-    <summary>原文</summary>
-
-If you’re using Stimulus for Rails together with an import map, the integration will automatically load all controller files from app/javascript/controllers.
-</details>
-
-## コントローラのファイル名と識別子の対応
+### コントローラのファイル名と識別子の対応
 
 コントローラファイルの名前は`[identifier]_controller.js`とします。`identifier`は、HTML内の各コントローラの data-controllerの値に設定する識別子に対応します。
 
@@ -41,8 +37,15 @@ Stimulus for Railsでは、ファイル名の複数の単語をアンダース�
 | users/list_item_controller.js | users--list-item |
 | local-time-controller.js | local-time |
 
+
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Using Stimulus for Rails
+
+If you’re using Stimulus for Rails together with an import map, the integration will automatically load all controller files from app/javascript/controllers.
+
+### Controller Filenames Map to Identifiers
 
 Name your controller files [identifier]_controller.js, where identifier corresponds to each controller’s data-controller identifier in your HTML.
 
@@ -74,7 +77,9 @@ Stimulus.load(definitionsFromContext(context))
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Using Webpack Helpers
 
 If you’re using Webpack as your JavaScript bundler, you can use the `@hotwired/stimulus-webpack-helpers` package to get the same form of autoloading behavior as Stimulus for Rails. First add the package, then use it like this:
 
@@ -107,7 +112,9 @@ Stimulus.register("clipboard", ClipboardController)
 esbuildのようなビルダーでstimulus-railsを使用している場合、`stimulus:manifest:update` Rakeタスクと`./bin/rails generate stimulus [controller] generator`を使用して、`app/javascript/controllers/index.js`にあるコントローラのインデックスファイルを自動的に更新することができます。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Using Other Build Systems
 
 Stimulus works with other build systems too, but without support for controller autoloading. Instead, you must explicitly load and register controller files with your application instance:
 
@@ -157,7 +164,9 @@ If you’re using stimulus-rails with a builder like esbuild, you can use the st
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Using Without a Build System
 
 If you prefer not to use a build system, you can load Stimulus in a `<script type="module">` tag:
 
@@ -211,7 +220,9 @@ window.Stimulus = Application.start(document.documentElement, customSchema);
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Overriding Attribute Defaults
 
 In case Stimulus data-* attributes conflict with another library in your project, they can be overridden when creating the Stimulus Application.
 
@@ -254,7 +265,9 @@ Stimulus.handleError = (error, message, detail) => {
 ```
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Error handling
 
 All calls from Stimulus to your application’s code are wrapped in a try ... catch block.
 
@@ -279,7 +292,9 @@ Stimulus.handleError = (error, message, detail) => {
 Stimulusアプリケーションを`window.Stimulus`に割り当てている場合、`Stimulus.debug = true`でコンソールからデバッグモードをオンにすることができます。 このフラグはソースコードでアプリケーションインスタンスを作成するときにも設定できます。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Debugging
 
 If you’ve assigned your Stimulus application to window.Stimulus, you can turn on debugging mode from the console with Stimulus.debug = true. You can also set this flag when you’re configuring your application instance in the source code.
 </details>
@@ -289,7 +304,9 @@ If you’ve assigned your Stimulus application to window.Stimulus, you can turn 
 Stimulusは、すべてのエバーグリーンブラウザ(デスクトップおよびモバイル)をサポートしています。 また、Stimulus 3+はInternet Explorer 11をサポートしていません（しかし、その場合`@stimulus/polyfills`とStimulus 2を使用することができます）。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## Browser Support
 
 Stimulus supports all evergreen, self-updating desktop and mobile browsers out of the box. Stimulus 3+ does not support Internet Explorer 11 (but you can use Stimulus 2 with the @stimulus/polyfills for that).
 </details>

--- a/stimulus/handbook/introduction.md
+++ b/stimulus/handbook/introduction.md
@@ -14,16 +14,6 @@ Stimulusは控えめな野心を持ったJavaScriptフレームワークです�
 
 class属性がHTMLとCSSをつなぐ橋であるように、Stimulusの`data-controller`属性はHTMLとJavaScript をつなぐ橋なのです。
 
-<details>
-    <summary>原文</summary>
-Stimulus is a JavaScript framework with modest ambitions. Unlike other front-end frameworks, Stimulus is designed to enhance static or server-rendered HTML—the “HTML you already have”—by connecting JavaScript objects to elements on the page using simple annotations.
-
-These JavaScript objects are called controllers, and Stimulus continuously monitors the page waiting for HTML data-controller attributes to appear. For each attribute, Stimulus looks at the attribute’s value to find a corresponding controller class, creates a new instance of that class, and connects it to the element.
-
-You can think of it this way: just like the class attribute is a bridge connecting HTML to CSS, Stimulus’s data-controller attribute is a bridge connecting HTML to JavaScript.
-</details>
-
-
 コントローラーの他にも、3つの主要なStimulusのコンセプトがあります。
 
 * actions: `data-action`属性を使用してコントローラのメソッドをDOM イベントに接続します。
@@ -35,7 +25,15 @@ Stimulus のデータ属性の使用は、CSSがコンテンツとプレゼン�
 その結果、Stimulus は小さくて再利用可能なコントローラを構築するのに役立ち、コードがごった煮になるのを防いでくれます。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## About Stimulus
+
+Stimulus is a JavaScript framework with modest ambitions. Unlike other front-end frameworks, Stimulus is designed to enhance static or server-rendered HTML—the “HTML you already have”—by connecting JavaScript objects to elements on the page using simple annotations.
+
+These JavaScript objects are called controllers, and Stimulus continuously monitors the page waiting for HTML data-controller attributes to appear. For each attribute, Stimulus looks at the attribute’s value to find a corresponding controller class, creates a new instance of that class, and connects it to the element.
+
+You can think of it this way: just like the class attribute is a bridge connecting HTML to CSS, Stimulus’s data-controller attribute is a bridge connecting HTML to JavaScript.
 
 Aside from controllers, the three other major Stimulus concepts are:
 
@@ -62,7 +60,10 @@ In turn, Stimulus helps you build small, reusable controllers, giving you just e
 それでは始めましょう！
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+## About This Book
+
 This handbook will guide you through Stimulus’s core concepts by demonstrating how to write several fully functional controllers. Each chapter builds on the one before it; from start to finish, you’ll learn how to:
 
 print a greeting addressed to the name in a text field

--- a/stimulus/handbook/managing-state.md
+++ b/stimulus/handbook/managing-state.md
@@ -81,10 +81,11 @@ export default class extends Controller {
 >
 > これらのメソッドはStimulusのライフサイクルコールバックメソッドで、コントローラがドキュメントに入ったり出たりするときに、関連する状態をセットアップしたりテールダウンしたりするのに便利です。
 >
-> | mathod | Stimulusによって呼び出されるタイミング... |
+> | メソッド         | Stimulusによって呼び出されるタイミング...   |
+> |--------------|------------------------------|
 > | initialize() | コントローラが最初にインスタンス化されたとき(一度だけ) |
-> | connect() | コントローラが DOM に接続されたとき(何度でも) |
-> | disconnect() | コントローラが DOM から切断されたとき(何度でも) |
+> | connect()    | コントローラが DOM に接続されたとき(何度でも)   |
+> | disconnect() | コントローラが DOM から切断されたとき(何度でも)  | 
 
 ページを再読み込みし、Next ボタンが次のスライドに進むことを確認します。
 
@@ -214,7 +215,7 @@ This might get the job done, but it’s clunky, requires us to make a decision a
 </details>
 
 
-## Valuesを使う
+### Valuesを使う
 
 Stimulusコントローラはデータ属性に自動的にマッピングされる型付き値プロパティをサポートしています。 コントローラクラスの先頭に`values`の定義を追加します：
 
@@ -437,7 +438,7 @@ Reload the page and confirm the slideshow behavior is the same.
 Stimulus calls the indexValueChanged() method at initialization and in response to any change to the data-slideshow-index-value attribute. You can even fiddle with the attribute in the web inspector and the controller will change slides in response. Go ahead—try it out!
 </details>
 
-## デフォルト値を指定する
+### デフォルト値を指定する
 
 `static values`の行を少し変更すればデフォルト値を設定することも可能です。 デフォルト値の指定は次のように行います：
 

--- a/stimulus/handbook/managing-state.md
+++ b/stimulus/handbook/managing-state.md
@@ -11,7 +11,10 @@ order: 5
 一方でStimulus は異なるアプローチをとります。 StimulusアプリケーションのステートはDOM内の属性として存在し、コントローラ自体はほとんどステートを持ちません。 このアプローチにより、初期状態のドキュメント、Ajaxリクエスト、Turbo visit、あるいは別のJavaScriptライブラリなど、どこからでも HTML を扱うことができ、明示的な初期化ステップなしに、関連するコントローラが自動的に起動させることができます。
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+# Managing State
+
 Most contemporary frameworks encourage you to keep state in JavaScript at all times. They treat the DOM as a write-only rendering target, reconciled by client-side templates consuming JSON from the server.
 
 Stimulus takes a different approach. A Stimulus application’s state lives as attributes in the DOM; controllers themselves are largely stateless. This approach makes it possible to work with HTML from anywhere—the initial document, an Ajax request, a Turbo visit, or even another JavaScript library—and have associated controllers spring to life automatically without any explicit initialization step.
@@ -92,7 +95,8 @@ export default class extends Controller {
 
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
 ## Building a Slideshow
 
 In the last chapter, we learned how a Stimulus controller can maintain simple state in the document by adding a class name to an element. But what do we do when we need to store a value, not just a simple flag?
@@ -164,8 +168,6 @@ We initialize the controller by showing the first slide, and the next() and prev
 > Reload the page and confirm that the Next button advances to the next slide.
 </details>
 
-
-
 ## Reading Initial State from the DOM
 
 コントローラが、`this.index`プロパティで、その状態（現在選択されているスライド）をどのように追跡しているかに注目してください。
@@ -190,7 +192,9 @@ initialize() {
 これでやりたいことは実現できるかもしれませんが、これではまだ幾分扱いにくく感じます。 インデックスをインクリメントして結果をDOMに永続化することができなかったり、属性名を考えたりする必要があります。
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Reading Initial State from the DOM
 
 Notice how our controller tracks its state—the currently selected slide—in the this.index property.
 
@@ -250,7 +254,10 @@ export default class extends Controller {
 
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+### Using Values
+
 Stimulus controllers support typed value properties which automatically map to data attributes. When we add a value definition to the top of our controller class:
 
 ```javascript
@@ -322,7 +329,8 @@ export default class extends Controller {
 
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
 Similar to targets, you define values in a Stimulus controller by describing them in a static object property called values. In this case, we’ve defined a single numeric value called index. You can read more about value definitions in the reference documentation.
 
 Now let’s update initialize() and the other methods in the controller to use this.indexValue instead of this.index. Here’s how the controller should look when we’re done:
@@ -399,7 +407,10 @@ export default class extends Controller {
 Stimulusは初期化時および`data-slideshow-index-value`属性の変更に応じて`indexValueChanged()`メソッドを呼び出します。 Webインスペクタで属性をいじれば、コントローラがそれに応答してスライドを変更します。 ぜひ試してみてください！
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Change Callbacks
+
 Our revised controller improves on the original version, but the repeated calls to this.showCurrentSlide() stand out. We have to manually update the state of the document when the controller initializes and after every place where we update this.indexValue.
 
 We can define a Stimulus value change callback to clean up the repetition and specify how the controller should respond whenever the index value changes.
@@ -453,7 +464,10 @@ static values = { index: Number, effect: { type: String, default: "kenburns" } }
 ```
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+### Setting Defaults
+
 It’s also possible to set a default values as part of the static definition. This is done like so:
 
 ```javascript
@@ -477,7 +491,10 @@ That would start the index at 2, if no data-slideshow-index-value attribute was 
 
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Wrap-Up and Next Steps
+
 In this chapter we’ve seen how to use the values to load and persist the current index of a slideshow controller.
 
 From a usability perspective, our controller is incomplete. The Previous button appears to do nothing when you are looking at the first slide. Internally, indexValue decrements from 0 to -1. Could we make the value wrap around to the last slide index instead? (There’s a similar problem with the Next button.)

--- a/stimulus/handbook/origin.md
+++ b/stimulus/handbook/origin.md
@@ -22,7 +22,10 @@ order: 0
 
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+# The Origin of Stimulus
+
 We write a lot of JavaScript at Basecamp, but we don’t use it to create “JavaScript applications” in the contemporary sense. All our applications have server-side rendered HTML at their core, then add sprinkles of JavaScript to make them sparkle.
 
 This is the way of the majestic monolith. Basecamp runs across half a dozen platforms, including native mobile apps, with a single set of controllers, views, and models created using Ruby on Rails. Having a single, shared interface that can be updated in a single place is key to being able to perform with a small team, despite the many platforms.
@@ -55,7 +58,10 @@ Stimulus以前は、Basecampは様々なスタイルやパターンを使って�
 このように新しいコードを追加するのは簡単でしたが、包括的な解決策にはならず、社内にはあまりにも多くのスタイルやパターンが共存していました。 そのためコードを再利用することが難しく、新しい開発者が一貫したアプローチを学ぶことも難しかったのです。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+### Turbo up high, Stimulus down low
+
 Before I get to Stimulus, our new modest JavaScript framework, allow me to recap the proposition of Turbo.
 
 Turbo descends from an approach called pjax, developed at GitHub. The basic concept remains the same. The reason full-page refreshes often feel slow is not so much because the browser has to process a bunch of HTML sent from a server. Browsers are really good and really fast at that. And in most cases, the fact that an HTML payload tends to be larger than a JSON payload doesn’t matter either (especially with gzipping). No, the reason is that CSS and JavaScript has to be reinitialized and reapplied to the page again. Regardless of whether the files themselves are cached. This can be pretty slow if you have a fair amount of CSS and JavaScript.
@@ -93,7 +99,10 @@ Stimulusは、こうして作られた既存のHTML文書を操作すること�
 時にはStimulusに新しいDOM要素を作成させたい場合もあるでしょう。 将来的には、それを簡単にするための方法も追加するかもしれません。 しかし、それはあまり多くない使用例です。 私たちは要素を作成するのではなく、操作することに重点を置いています。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+### The three core concepts in Stimulus
+
 Stimulus rolls up the best of those patterns into a modest, small framework revolving around just three main concepts: Controllers, actions, and targets.
 
 It’s designed to read as a progressive enhancement when you look at the HTML it’s addressing. Such that you can look at a single template and know which behavior is acting upon it. Here’s an example:
@@ -125,7 +134,10 @@ Stimulusはまた、ステートの扱いに関しても他のフレームワー
 その一方で、あなたが今取り組んでいることが、そのような現代的なテクニックが意味するような強烈な複雑さやアプリケーションの分離を正当化するものではないと強く感じているのであれば、私たちのアプローチに救いを見出すことができるでしょう。
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+### How Stimulus differs from mainstream JavaScript frameworks
+
 This makes Stimulus very different from the majority of contemporary JavaScript frameworks. Almost all are focused on turning JSON into DOM elements via a template language of some sort. Many use these frameworks to birth an empty page, which is then filled exclusively with elements created through this JSON-to-template rendering.
 
 Stimulus also differs on the question of state. Most frameworks have ways of maintaining state within JavaScript objects, and then render HTML based on that state. Stimulus is the exact opposite. State is stored in the HTML, so that controllers can be discarded between page changes, but still reinitialize as they were when the cached HTML appears again.
@@ -154,7 +166,10 @@ Basecampでも、必要に応じて、いくつかの重たいアプローチを
 David Heinemeier Hansson
 
 <details>
-    <summary>原文</summary>
+<summary>原文</summary>
+
+### Stimulus and related ideas were extracted from the wild
+
 At Basecamp we’ve used this architecture across several different versions of Basecamp and other applications for years. GitHub has used a similar approach to great effect. This is not only a valid alternative to the mainstream understanding of what a “modern” web application looks like, it’s an incredibly compelling one.
 
 In fact, it feels like the same kind of secret sauce we had at Basecamp when we developed Ruby on Rails. The sense that contemporary mainstream approaches are needlessly convoluted, and that we can do more, faster, with far less.

--- a/stimulus/handbook/origin.md
+++ b/stimulus/handbook/origin.md
@@ -38,7 +38,7 @@ We wanted Basecamp to feel like that too. As though we had followed the herd and
 This desire led us to a two-punch solution: Turbo and Stimulus.
 </details>
 
-## Turboは高く、Stimulusは低く
+### Turboは高く、Stimulusは低く
 
 新しい控えめなJavaScriptフレームワークであるStimulusの説明に入る前に、Turboの命題をおさらいしておきましょう。
 
@@ -71,7 +71,7 @@ Prior to Stimulus, Basecamp used a smattering of different styles and patterns t
 While it was easy to add new code like this, it wasn’t a comprehensive solution, and we had too many in-house styles and patterns coexisting. That made it hard to reuse code, and it made it hard for new developers to learn a consistent approach.
 </details>
 
-## Stimulusの3つのコアコンセプト
+### Stimulusの3つのコアコンセプト
 
 Stimulusは、これらのパターンの良いところをまとめあげ、コントローラー、アクション、ターゲットという3つの主要な概念だけを中心とした、控えめで小さなフレームワークです。
 
@@ -114,7 +114,7 @@ Stimulus is concerned with manipulating this existing HTML document. Sometimes t
 There are cases where you’d want Stimulus to create new DOM elements, and you’re definitely free to do that. We might even add some sugar to make it easier in the future. But it’s the minority use case. The focus is on manipulating, not creating elements.
 </details>
 
-## Stimulusと主流のJavaScriptフレームワークとの違い
+### Stimulusと主流のJavaScriptフレームワークとの違い
 
 そのため、Stimulusは現代のJavaScriptフレームワークの大半とは大きく異なっています。 ほとんどすべてのフレームワークは、ある種のテンプレート言語を介してJSONをDOM要素に変換することに重点を置いています。 これらのフレームワークの多くは、空のページを作成し、そのページをJSONを元にしたテンプレートレンダリングによって作成された要素のみで埋めるために使用します。
 
@@ -135,7 +135,7 @@ It really is a remarkably different paradigm. One that I’m sure many veteran J
 If, on the other hand, you have nagging sense that what you’re working on does not warrant the intense complexity and application separation such contemporary techniques imply, then you’re likely to find refuge in our approach.
 </details>
 
-## Stimulusと関連するアイデアは、自然に抽出されたもの
+### Stimulusと関連するアイデアは、自然に抽出されたもの
 
 Basecampでは、このアーキテクチャをBasecampのいくつかのバージョンや他のアプリケーションで長年使ってきました。 GitHubも同様のアプローチで大きな効果を上げています。 これは、 「モダンな」 Webアプリケーションがどのようなものであるかについての主流の考え方に対する有効な代替案であるだけでなく、信じられないほど説得力のあるものです。
 

--- a/stimulus/handbook/working-with-external-resources.md
+++ b/stimulus/handbook/working-with-external-resources.md
@@ -11,7 +11,10 @@ order: 6
 時折コントローラーは外部リソースの状態を取得しなければならない場合があります。 ここでの外部とは、DOMやStimulusの一部ではないものを指します。 例えば、HTTPリクエストを発行し、リクエストの状態の変化に応じて応答する必要があるかもしれません。 あるいは、タイマーを開始し、コントローラがdisconnectした時にタイマーを停止する必要があるかもしれません。 この章では、こういったケースに対応するための方法を説明します。
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+# Working With External Resources
+
 In the last chapter we learned how to load and persist a controller’s internal state using values.
 
 Sometimes our controllers need to track the state of external resources, where by external we mean anything that isn’t in the DOM or a part of Stimulus. For example, we may need to issue an HTTP request and respond as the request’s state changes. Or we may want to start a timer and then stop it when the controller is no longer connected. In this chapter we’ll see how to do both of those things.
@@ -67,7 +70,10 @@ export default class extends Controller {
 ブラウザの開発者コンソールでネットワークタブを開き、ページをリロードします。 最初のページロードを表すリクエストと、それに続く`messages.html`へのリクエストが表示されましたね。
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Asynchronously Loading HTML
+
 Let’s learn how to populate parts of a page asynchronously by loading and inserting remote fragments of HTML. We use this technique in Basecamp to keep our initial page loads fast, and to keep our views free of user-specific content so they can be cached more effectively.
 
 We’ll build a general-purpose content loader controller which populates its element with HTML fetched from the server. Then we’ll use it to load a list of unread messages like you’d see in an email inbox.
@@ -162,7 +168,9 @@ connect() {
 
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Refreshing Automatically With a Timer
 
 Let’s improve our controller by changing it to periodically refresh the inbox so it’s always up-to-date.
 
@@ -283,7 +291,10 @@ export default class extends Controller {
 ```
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Releasing Tracked Resources
+
 We start our timer when the controller connects, but we never stop it. That means if our controller’s element were to disappear, the controller would continue to issue HTTP requests in the background.
 
 We can fix this issue by modifying our startRefreshing() method to keep a reference to the timer:
@@ -394,8 +405,9 @@ load({ params: { url } }) {
 ```
 
 <details>
-    <summary>原文</summary/>
-If we wanted to make the loader work with multiple different sources, we could do it using action parameters. Take this HTML:
+    <summary>原文</summary>
+
+## Using action parameters
 
 ```html
 <div data-controller="content-loader">
@@ -436,7 +448,10 @@ We could even destruct the params to just get the URL parameter:
 次に、独自のアプリケーションにStimulus をインストールして設定する方法を説明します。
 
 <details>
-    <summary>原文</summary/>
+<summary>原文</summary>
+
+## Wrap-Up and Next Steps
+
 In this chapter we’ve seen how to acquire and release external resources using Stimulus lifecycle callbacks.
 
 Next we’ll see how to install and configure Stimulus in your own application.


### PR DESCRIPTION
details タグの記述ミス、テーブルの崩れなどを修正しました。
また原文と見出しの強さが異なっている箇所を原文と合わせました（h3がh2になっていた）

原文のベースは 422eb81 時点のものです。