### PR TITLE
turbo handbook drive: updated translation

### DIFF
--- a/turbo/handbook/drive.md
+++ b/turbo/handbook/drive.md
@@ -15,6 +15,8 @@ ${toc}
 <details>
 <summary>原文</summary>
 
+# Navigate with Turbo Drive
+
 Turbo Drive is the part of Turbo that enhances page-level navigation. It watches for link clicks and form submissions, performs them in the background, and updates the page without doing a full reload. It's the evolution of a library previously known as [Turbolinks](https://github.com/turbolinks/turbolinks).
 
 </details>
@@ -31,6 +33,8 @@ Turbo ドライブは、ページ・ナビゲーションを、ある*アクシ�
 
 <details>
 <summary>原文</summary>
+
+## Page Navigation Basics
 
 Turbo Drive models page navigation as a *visit* to a *location* (URL) with an *action*.
 
@@ -84,6 +88,8 @@ Turbo.visit("/edit", { action: "replace" })
 <details>
 <summary>原文</summary>
 
+## Application Visits
+
 Application visits are initiated by clicking a Turbo Drive-enabled link, or programmatically by calling [`Turbo.visit(location)`](/reference/drive#turbodrivevisit).
 
 An application visit always issues a network request. When the response arrives, Turbo Drive renders its HTML and completes the visit.
@@ -135,6 +141,8 @@ Applications using the Turbo Drive [iOS adapter](https://github.com/hotwired/tur
 <details>
 <summary>原文</summary>
 
+## Restoration Visits
+
 Turbo Drive automatically initiates a restoration visit when you navigate with the browser’s Back or Forward buttons. Applications using the [iOS](https://github.com/hotwired/turbo-ios) or [Android](https://github.com/hotwired/turbo-android) adapters initiate a restoration visit when moving backward in the navigation stack.
 
 ![Restore visit action](https://s3.amazonaws.com/turbolinks-docs/images/restore.svg)
@@ -158,6 +166,8 @@ Application visits can be canceled before they start, regardless of whether they
 
 <details>
 <summary>原文</summary>
+
+## Canceling Visits Before They Start
 
 Application visits can be canceled before they start, regardless of whether they were initiated by a link click or a call to [`Turbo.visit`](/reference/drive#turbovisit).
 
@@ -187,6 +197,8 @@ addEventListener("turbo:before-render", (event) => {
 
 <details>
 <summary>原文</summary>
+
+## Custom Rendering
 
 Applications can customize the rendering process by adding a document-wide `turbo:before-render` event listener and overriding the `event.detail.render` property.
 
@@ -224,6 +236,8 @@ document.addEventListener("turbo:before-render", async (event) => {
 
 <details>
 <summary>原文</summary>
+
+## Pausing Rendering
 
 Applications can pause rendering and make additional preparations before continuing.
 
@@ -263,6 +277,8 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
+## Pausing Requests
+
 Application can pause request and make additional preparation before it will be executed.
 
 Listen for the `turbo:before-fetch-request` event to be notified when a request is about to start, and pause it using `event.preventDefault()`. Once the preparation is done continue request by calling `event.detail.resume()`.
@@ -294,6 +310,8 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
+## Performing Visits With a Different Method
+
 By default, link clicks send a `GET` request to your server. But you can change this with `data-turbo-method`:
 
 ```html
@@ -317,6 +335,8 @@ You should consider that for accessibility reasons, it's better to use actual fo
 
 <details>
 <summary>原文</summary>
+
+## Requiring Confirmation for a Visit
 
 Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confirmation will be required for a visit to proceed.
 
@@ -371,6 +391,8 @@ Turbo.session.drive = false
 
 <details>
 <summary>原文</summary>
+
+## Disabling Turbo Drive on Specific Links or Forms
 
 Turbo Drive can be disabled on a per-element basis by annotating the element or any of its ancestors with `data-turbo="false"`.
 
@@ -436,6 +458,8 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
+## View transitions
+
 In [browsers that support](https://caniuse.com/?search=View%20Transition%20API) the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) Turbo can trigger view transitions when navigating between pages.
 
 Turbo triggers a view transition when both the current and the next page have this meta tag:
@@ -492,6 +516,8 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
+## Displaying Progress
+
 During Turbo Drive navigation, the browser will not display its native progress indicator. Turbo Drive installs a CSS-based progress bar to provide feedback while issuing a request.
 
 The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load. (You can change this delay with the [`Turbo.setProgressBarDelay`](/reference/drive#turbodrivesetprogressbardelay) method.)
@@ -538,6 +564,8 @@ In tandem with the progress bar, Turbo Drive will also toggle the [`[aria-busy]`
 <details>
 <summary>原文</summary>
 
+## Reloading When Assets Change
+
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. However, if CSS or JavaScript change, that merge would evaluate them on top of the existing one. Typically, this would lead to undesirable conflicts. In such cases, it's necessary to fetch a completely new document through a standard, non-Ajax request.
 
 To accomplish this, just annotate those asset elements with `data-turbo-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
@@ -575,6 +603,8 @@ To accomplish this, just annotate those asset elements with `data-turbo-track="r
 <details>
 <summary>原文</summary>
 
+## Removing Assets When They Change
+
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. When a page depends on external assets like CSS stylesheets that other pages do not, it can be useful to remove them when navigating away from the page.
 
 Rendering a `<link>` or `<style>` element with `[data-turbo-track="dynamic"]` instructs Turbo Drive to dynamically remove the element when it is absent from a navigation's response, and can serve a complementary role to the [`[data-turbo-track="reload"]`](#reloading-when-assets-change) attribute to avoid triggering a full page reload when deploying changes that only affect styles.
@@ -610,6 +640,8 @@ Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` migh
 <details>
 <summary>原文</summary>
 
+## Ensuring Specific Pages Trigger a Full Reload
+
 You can ensure visits to a certain page will always trigger a full reload by including a `<meta name="turbo-visit-control">` element in the page’s `<head>`.
 
 ```html
@@ -641,6 +673,8 @@ Turbo ドライブは同じオリジンでのURLのみをロード対象とし�
 
 <details>
 <summary>原文</summary>
+
+## Setting a Root Location
 
 Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
 
@@ -690,6 +724,8 @@ addEventListener("turbo:submit-start", ({ target }) => {
 <details>
 <summary>原文</summary>
 
+## Form Submissions
+
 Turbo Drive handles form submissions in a manner similar to link clicks. The key difference is that form submissions can issue stateful requests using the HTTP POST method, while link clicks only ever issue stateless HTTP GET requests.
 
 Throughout a submission, Turbo Drive will dispatch a series of [events][] that
@@ -737,6 +773,8 @@ Turbo が POST リクエストに通常の200ステータスの応答を許さ�
 <details>
 <summary>原文</summary>
 
+## Redirecting After a Form Submission
+
 After a stateful request from a form submission, Turbo Drive expects the server to return an [HTTP 303 redirect response](https://en.wikipedia.org/wiki/HTTP_303), which it will then follow and use to navigate and update the page without reloading.
 
 The exception to this rule is when the response is rendered with either a 4xx or 5xx status code. This allows form validation errors to be rendered by having the server respond with `422 Unprocessable Content` and a broken server to display a "Something Went Wrong" screen on a `500 Internal Server Error`.
@@ -753,6 +791,8 @@ If the form submission is a GET request, you may render the directly rendered re
 
 <details>
 <summary>原文</summary>
+
+## Streaming After a Form Submission
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
 
@@ -828,6 +868,8 @@ function hasSlowInternet() {
 
 <details>
 <summary>原文</summary>
+
+## Prefetching Links on Hover
 
 Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
 
@@ -917,6 +959,8 @@ function hasSlowInternet() {
 <details>
 <summary>原文</summary>
 
+## Preload Links Into the Cache
+
 Preload links into Turbo Drive's cache using the [data-turbo-preload][] boolean attribute.
 
 This will make page transitions feel lightning fast by providing a preview of a page even before the first visit. Use it to preload the most important pages in your application. Avoid over usage, as it will lead to loading content that is not needed.
@@ -984,6 +1028,8 @@ It also dovetails nicely with pages that leverage [Eager-Loading Frames](/refere
 
 <details>
 <summary>原文</summary>
+
+## Ignored Paths
 
 Paths with a `.` in the last level of a path/URL will not be handled by Turbo unless they end in a file extension `.htm`, `.html`, `.xhtml`, or `.php`. Turbo will ignore forms and links that target these paths. The quickest way to get Turbo to target these paths is to add a `/` at the end of the URL. Examples of forms that would be ignored:
 

--- a/turbo/handbook/drive.md
+++ b/turbo/handbook/drive.md
@@ -15,7 +15,7 @@ ${toc}
 <details>
 <summary>原文</summary>
 
-# Navigate with Turbo Drive
+**Navigate with Turbo Drive**
 
 Turbo Drive is the part of Turbo that enhances page-level navigation. It watches for link clicks and form submissions, performs them in the background, and updates the page without doing a full reload. It's the evolution of a library previously known as [Turbolinks](https://github.com/turbolinks/turbolinks).
 
@@ -34,7 +34,7 @@ Turbo ドライブは、ページ・ナビゲーションを、ある*アクシ�
 <details>
 <summary>原文</summary>
 
-## Page Navigation Basics
+**Page Navigation Basics**
 
 Turbo Drive models page navigation as a *visit* to a *location* (URL) with an *action*.
 
@@ -88,7 +88,7 @@ Turbo.visit("/edit", { action: "replace" })
 <details>
 <summary>原文</summary>
 
-## Application Visits
+**Application Visits**
 
 Application visits are initiated by clicking a Turbo Drive-enabled link, or programmatically by calling [`Turbo.visit(location)`](/reference/drive#turbodrivevisit).
 
@@ -141,7 +141,7 @@ Applications using the Turbo Drive [iOS adapter](https://github.com/hotwired/tur
 <details>
 <summary>原文</summary>
 
-## Restoration Visits
+**Restoration Visits**
 
 Turbo Drive automatically initiates a restoration visit when you navigate with the browser’s Back or Forward buttons. Applications using the [iOS](https://github.com/hotwired/turbo-ios) or [Android](https://github.com/hotwired/turbo-android) adapters initiate a restoration visit when moving backward in the navigation stack.
 
@@ -167,7 +167,7 @@ Application visits can be canceled before they start, regardless of whether they
 <details>
 <summary>原文</summary>
 
-## Canceling Visits Before They Start
+**Canceling Visits Before They Start**
 
 Application visits can be canceled before they start, regardless of whether they were initiated by a link click or a call to [`Turbo.visit`](/reference/drive#turbovisit).
 
@@ -198,7 +198,7 @@ addEventListener("turbo:before-render", (event) => {
 <details>
 <summary>原文</summary>
 
-## Custom Rendering
+**Custom Rendering**
 
 Applications can customize the rendering process by adding a document-wide `turbo:before-render` event listener and overriding the `event.detail.render` property.
 
@@ -237,7 +237,7 @@ document.addEventListener("turbo:before-render", async (event) => {
 <details>
 <summary>原文</summary>
 
-## Pausing Rendering
+**Pausing Rendering**
 
 Applications can pause rendering and make additional preparations before continuing.
 
@@ -277,7 +277,7 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
-## Pausing Requests
+**Pausing Requests**
 
 Application can pause request and make additional preparation before it will be executed.
 
@@ -310,7 +310,7 @@ document.addEventListener("turbo:before-fetch-request", async (event) => {
 <details>
 <summary>原文</summary>
 
-## Performing Visits With a Different Method
+**Performing Visits With a Different Method**
 
 By default, link clicks send a `GET` request to your server. But you can change this with `data-turbo-method`:
 
@@ -336,7 +336,7 @@ You should consider that for accessibility reasons, it's better to use actual fo
 <details>
 <summary>原文</summary>
 
-## Requiring Confirmation for a Visit
+**Requiring Confirmation for a Visit**
 
 Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confirmation will be required for a visit to proceed.
 
@@ -392,7 +392,7 @@ Turbo.session.drive = false
 <details>
 <summary>原文</summary>
 
-## Disabling Turbo Drive on Specific Links or Forms
+**Disabling Turbo Drive on Specific Links or Forms**
 
 Turbo Drive can be disabled on a per-element basis by annotating the element or any of its ancestors with `data-turbo="false"`.
 
@@ -458,7 +458,7 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
-## View transitions
+**View transitions**
 
 In [browsers that support](https://caniuse.com/?search=View%20Transition%20API) the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) Turbo can trigger view transitions when navigating between pages.
 
@@ -516,7 +516,7 @@ html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-ch
 <details>
 <summary>原文</summary>
 
-## Displaying Progress
+**Displaying Progress**
 
 During Turbo Drive navigation, the browser will not display its native progress indicator. Turbo Drive installs a CSS-based progress bar to provide feedback while issuing a request.
 
@@ -564,7 +564,7 @@ In tandem with the progress bar, Turbo Drive will also toggle the [`[aria-busy]`
 <details>
 <summary>原文</summary>
 
-## Reloading When Assets Change
+**Reloading When Assets Change**
 
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. However, if CSS or JavaScript change, that merge would evaluate them on top of the existing one. Typically, this would lead to undesirable conflicts. In such cases, it's necessary to fetch a completely new document through a standard, non-Ajax request.
 
@@ -603,7 +603,7 @@ To accomplish this, just annotate those asset elements with `data-turbo-track="r
 <details>
 <summary>原文</summary>
 
-## Removing Assets When They Change
+**Removing Assets When They Change**
 
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. When a page depends on external assets like CSS stylesheets that other pages do not, it can be useful to remove them when navigating away from the page.
 
@@ -640,7 +640,7 @@ Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` migh
 <details>
 <summary>原文</summary>
 
-## Ensuring Specific Pages Trigger a Full Reload
+**Ensuring Specific Pages Trigger a Full Reload**
 
 You can ensure visits to a certain page will always trigger a full reload by including a `<meta name="turbo-visit-control">` element in the page’s `<head>`.
 
@@ -674,7 +674,7 @@ Turbo ドライブは同じオリジンでのURLのみをロード対象とし�
 <details>
 <summary>原文</summary>
 
-## Setting a Root Location
+**Setting a Root Location**
 
 Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
 
@@ -724,7 +724,7 @@ addEventListener("turbo:submit-start", ({ target }) => {
 <details>
 <summary>原文</summary>
 
-## Form Submissions
+**Form Submissions**
 
 Turbo Drive handles form submissions in a manner similar to link clicks. The key difference is that form submissions can issue stateful requests using the HTTP POST method, while link clicks only ever issue stateless HTTP GET requests.
 
@@ -773,7 +773,7 @@ Turbo が POST リクエストに通常の200ステータスの応答を許さ�
 <details>
 <summary>原文</summary>
 
-## Redirecting After a Form Submission
+**Redirecting After a Form Submission**
 
 After a stateful request from a form submission, Turbo Drive expects the server to return an [HTTP 303 redirect response](https://en.wikipedia.org/wiki/HTTP_303), which it will then follow and use to navigate and update the page without reloading.
 
@@ -792,7 +792,7 @@ If the form submission is a GET request, you may render the directly rendered re
 <details>
 <summary>原文</summary>
 
-## Streaming After a Form Submission
+**Streaming After a Form Submission**
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
 
@@ -869,7 +869,7 @@ function hasSlowInternet() {
 <details>
 <summary>原文</summary>
 
-## Prefetching Links on Hover
+**Prefetching Links on Hover**
 
 Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
 
@@ -959,7 +959,7 @@ function hasSlowInternet() {
 <details>
 <summary>原文</summary>
 
-## Preload Links Into the Cache
+**Preload Links Into the Cache**
 
 Preload links into Turbo Drive's cache using the [data-turbo-preload][] boolean attribute.
 
@@ -1029,7 +1029,7 @@ It also dovetails nicely with pages that leverage [Eager-Loading Frames](/refere
 <details>
 <summary>原文</summary>
 
-## Ignored Paths
+**Ignored Paths**
 
 Paths with a `.` in the last level of a path/URL will not be handled by Turbo unless they end in a file extension `.htm`, `.html`, `.xhtml`, or `.php`. Turbo will ignore forms and links that target these paths. The quickest way to get Turbo to target these paths is to add a `/` at the end of the URL. Examples of forms that would be ignored:
 

--- a/turbo/handbook/drive.md
+++ b/turbo/handbook/drive.md
@@ -2,7 +2,7 @@
 title: "Turbo ドライブを使ったナビゲート"
 description: "Turbo ドライブは、ページ全体の再読み込みの必要を無くすことで、リンクとフォームの送信を高速化します。"
 order: 2
-commit: "aa10dcf"
+commit: "79760f0"
 ---
 
 # Turbo ドライブを使ったナビゲート
@@ -558,7 +558,7 @@ To accomplish this, just annotate those asset elements with `data-turbo-track="r
 ページが他のページにはないCSSスタイルシートのような外部アセットに依存している場合、ページから離れるときにそれらの外部アセットを削除すると便利です。
 
 `<link>` 要素または `<style>` 要素を`[data-turbo-track="dynamic"]`で描画すると、遷移時のレスポンスにその要素がない場合に動的に削除するようTurbo ドライブに指示します。
-また、スタイルにのみ影響する変更を展開する際、全ページのリロードを避けるために[`[data-turbo-track="reload"]`](#reload-when-assets-change) 属性を補完する役割を担います。
+また、スタイルにのみ影響する変更を展開する際、全ページのリロードを避けるために[`[data-turbo-track="reload"]`](#アセット変更時のリロード) 属性を補完する役割を担います。
 
 ```html
 <head>
@@ -577,7 +577,7 @@ To accomplish this, just annotate those asset elements with `data-turbo-track="r
 
 As we saw above, Turbo Drive merges the contents of the `<head>` elements. When a page depends on external assets like CSS stylesheets that other pages do not, it can be useful to remove them when navigating away from the page.
 
-Rendering a `<link>` or `<style>` element with `[data-turbo-track="dynamic"]` instructs Turbo Drive to dynamically remove the element when it is absent from a navigation's response, and can serve a complementary role to the [`[data-turbo-track="reload"]`](#reload-when-assets-change) attribute to avoid triggering a full page reload when deploying changes that only affect styles.
+Rendering a `<link>` or `<style>` element with `[data-turbo-track="dynamic"]` instructs Turbo Drive to dynamically remove the element when it is absent from a navigation's response, and can serve a complementary role to the [`[data-turbo-track="reload"]`](#reloading-when-assets-change) attribute to avoid triggering a full page reload when deploying changes that only affect styles.
 
 ```html
 <head>


### PR DESCRIPTION
## やったこと
- #175 の差分の更新対応
  - 現在最新の79760f0まで
- 原文に見出しの追加
  - 原文内に見出しへのリンクが埋め込まれている部分があったため、原文にも見出しが記載されていた方が親切かと思ったので追加した