### PR TITLE
npm: rename the npm script from publish to build

### DIFF
--- a/.github/workflows/eleventy_publish.yml
+++ b/.github/workflows/eleventy_publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: latest
       - run: npm ci
-      - run: npm run publish
+      - run: npm run build
       - name: Archive artifact
         shell: sh
         if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build site
-        run: npm run publish
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "serve": "npm-run-all -s clean build:11ty build:css -p watch:** --silent",
-    "publish": "run-s build:**",
+    "build": "run-s build:**",
     "clean": "del-cli \"_site\"",
     "build:11ty": "eleventy --pathprefix=hotwire_ja",
     "watch:11ty": "eleventy --serve --quiet",


### PR DESCRIPTION
The previous name was misleading because the script generates HTML rather than publishing.
The new name clarifies its actual purpose.